### PR TITLE
Improve Readme for installation flow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,9 +67,16 @@ FLOO_ROOT = $(shell $(BENDER) path floo_noc)
 FLOO_GEN	?= floogen
 FLOO_CFG = $(PB_ROOT)/cfg/picobello_noc.yml
 
+# Check if the "verible-verilog-format" is installed in the system
+# otherwise use the "--no-format" flag to generate FlooNoC.
+NO_FORMAT_FLAG ?=
+ifeq ($(shell command -v verible-verilog-format 2>/dev/null),)
+	NO_FORMAT_FLAG += --no-format
+endif
+
 floo-hw-all: $(PB_GEN_DIR)/floo_picobello_noc_pkg.sv
 $(PB_GEN_DIR)/floo_picobello_noc_pkg.sv: $(FLOO_CFG) | $(PB_GEN_DIR)
-	$(FLOO_GEN) -c $(FLOO_CFG) -o $(PB_GEN_DIR) --only-pkg
+	$(FLOO_GEN) -c $(FLOO_CFG) -o $(PB_GEN_DIR) --only-pkg $(NO_FORMAT_FLAG)
 
 floo-clean:
 	rm -rf $(PB_GEN_DIR)/floo_picobello_noc_pkg.sv

--- a/README.md
+++ b/README.md
@@ -4,9 +4,34 @@
 
 *picobello* is developed as part of the [PULP (Parallel Ultra-Low Power) project](https://pulp-platform.org/), a joint effort between ETH Zurich and the University of Bologna. *picobello* is also supported by the [EUPilot project](https://eupilot.eu), under the name MLS.
 
-## 🚧 Getting started
+## 🚧 Getting started (currently in early development)
+The first requirement you need to install is [Bender](https://github.com/pulp-platform/bender). Check if there is any pre-compiled release for your Operating System, otherwise follow the intructions to build your own binary using Rust.
 
-This repository is currently in early development and is not yet ready for general use. Please check back later for updates.
+At this point, the `make help` command prompts all the available make options on your terminal. To continue further, other python requirements that might need to be installed are `hjson`, `jsonref`, `jsonschema` (jsonschema version >4.0.0).
+
+### RTL code generation
+Generate the RTL code for Cheshire, FlooNoC, and Snitch by running `make all`.
+
+### Compile software tests
+Compiling the software tests requires two different toolchains to be exported.
+* Snitch software tests require the Clang compiler extended with Snitch-specific instructions. There are some precompiled releases available on the [PULP Platform LLVM Project](https://github.com/pulp-platform/llvm-project/releases/download/0.12.0/riscv32-pulp-llvm-ubuntu2004-0.12.0.tar.gz) fork that are ready to be downloaded and unzipped.
+* Cheshire requires a 64-bit GCC toolchain that can be installed from the [riscv-gnu-toolchain](https://github.com/riscv-collab/riscv-gnu-toolchain) git following the *Installation (Newlib)* intructions.
+
+Once LLVM and GCC are obtained, export a `LLVM_BINROOT` environment variable to the binary folder of the LLVM toolchain installation. Then, add the GCC binary folder to your `$PATH`.
+Only at this point, run `make sw` to build the tests for both Cheshire and Snitch.
+
+### Platform simulation
+The Picobello simulation flow currently only supports Questasim. The `make vsim-compile` command will build the RTL code.
+Tests can be executed by setting all the required command-line variable for Cheshire, see the [Cheshire Docs](https://pulp-platform.github.io/cheshire/gs/) for more details.
+To run a simple Chehire helloworld in Picobello, do the following:
+```
+make vsim-run CHS_BINARY=sw/cheshire/tests/helloworld.spm.elf
+```
+To run an offloading example test for Snitch, do:
+```
+make vsim-run CHS_BINARY=sw/cheshire/tests/simple_offload.spm.elf SN_BINARY=sw/snitch/tests/build/simple.elf
+```
+Use the `vsim-run-batch` command to run tests in batch mode with RTL optimizations to reduce the Questasim runtime.
 
 ## 🔐 License
 Unless specified otherwise in the respective file headers, all code checked into this repository is made available under a permissive license. All hardware sources are licensed under the Solderpad Hardware License 0.51 (see [`LICENSE`](LICENSE)), and all software sources are licensed under the Apache License 2.0.


### PR DESCRIPTION
* Extend the `Getting started` section in README
* Add check for `verible-verilog-format` system installation in Makefile before running Floogen with `--no-format` flag enabled