### PR TITLE
Lleone/reg tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -122,6 +122,7 @@ vsim-compile:
       # - { CHS_BINARY: $CHS_BUILD_DIR/sanity.spm.elf, PRELMODE: 2 } # UART preloading takes over 1h, maybe enable later again
       - { CHS_BINARY: $CHS_BUILD_DIR/sanity_fail.spm.elf, NZ_EXIT_CODE: 7}
       - { CHS_BINARY: $CHS_BUILD_DIR/helloworld.spm.elf, USTR: "Hello World!" }
+      - { CHS_BINARY: $CHS_BUILD_DIR/access_l2.spm.elf, PRELMODE: 1}
       - { CHS_BINARY: $CHS_BUILD_DIR/simple_offload.spm.elf, SN_BINARY: $SN_BUILD_DIR/simple.elf, PRELMODE: 0 }
       - { CHS_BINARY: $CHS_BUILD_DIR/simple_offload.spm.elf, SN_BINARY: $SN_BUILD_DIR/simple.elf, PRELMODE: 1 }
       # - { CHS_BINARY: $CHS_BUILD_DIR/simple_offload.spm.elf, SN_BINARY: $SN_BUILD_DIR/simple.elf, PRELMODE: 3 }

--- a/Bender.lock
+++ b/Bender.lock
@@ -44,8 +44,8 @@ packages:
     - common_cells
     - common_verification
   axi_rt:
-    revision: f6aff64c2da42adbd1f46684ebc7dc4227b0d422
-    version: null
+    revision: 50153a346b753dc2bc7723c446656a43db35d02d
+    version: 0.0.0-alpha.10
     source:
       Git: https://github.com/pulp-platform/axi_rt.git
     dependencies:
@@ -69,7 +69,7 @@ packages:
     - common_cells
     - register_interface
   cheshire:
-    revision: 9d746cced4e8fc4aa7403d7135a71ac0cf41ea82
+    revision: d5101a7884be55a3d7da8419353e7c6d34c8fb57
     version: null
     source:
       Git: https://github.com/pulp-platform/cheshire.git
@@ -151,8 +151,8 @@ packages:
     dependencies:
     - axi
   floo_noc:
-    revision: add4108261bbb2516311072b2989351b9bddab2d
-    version: null
+    revision: 71972efee8c8216af7ed1ee3f640e585cb5ba181
+    version: 0.6.0
     source:
       Git: https://github.com/pulp-platform/FlooNoC.git
     dependencies:
@@ -177,8 +177,8 @@ packages:
     dependencies:
     - common_cells
   idma:
-    revision: 1a42da9d5c76f1cff0bcdaaacc474ed85631d734
-    version: null
+    revision: ff5d56fffb3767814db88d6bf8f381974ea33aa5
+    version: 0.6.4
     source:
       Git: https://github.com/pulp-platform/iDMA.git
     dependencies:

--- a/Bender.yml
+++ b/Bender.yml
@@ -11,7 +11,7 @@ dependencies:
   register_interface: { git: "https://github.com/pulp-platform/register_interface.git", version: "0.4.5" }
   axi: { git: "https://github.com/pulp-platform/axi.git", version: "0.39.6" }
   common_cells: { git: "https://github.com/pulp-platform/common_cells.git", version: "1.37.0" }
-  cheshire: { git: "https://github.com/pulp-platform/cheshire.git", rev: "9d746cced4e8fc4aa7403d7135a71ac0cf41ea82" }
+  cheshire: { git: "https://github.com/pulp-platform/cheshire.git", rev: "d5101a7884be55a3d7da8419353e7c6d34c8fb57" }
   floo_noc: { git: "https://github.com/pulp-platform/FlooNoC.git", rev: "main"}
   snitch_cluster:  { git: "https://github.com/pulp-platform/snitch_cluster.git", rev: "soc-integration" }
 

--- a/sw/cheshire/tests/access_l2.c
+++ b/sw/cheshire/tests/access_l2.c
@@ -1,0 +1,54 @@
+// Copyright 2025 ETH Zurich and University of Bologna.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Lorenzo Leone <lleone@iis.ee.ethz.ch>
+//
+// This test simply read and write from some L2 locations.
+// It will read the first uint32 data from each memory bank.
+// Each memeory tile is organized as follow:
+// - L2Size = 1 MiB
+// - NumWordsPerBank = 512
+// - DataWidth = 256 bit
+// - BankSize = (NumWordsPerBank x DataWidth)/8 = 16 kiB [14 bits shift]
+// - NumBanks = L2Size/BankSize = 64 banks (Physical Banks)
+
+
+#include <stdint.h>
+#include "picobello_addrmap.h"
+
+#define TESTVAL 0xABCD9876
+#define BANKS_SIZE 0x00004000
+#define NUM_L2_LOG_BANKS 2
+#define NUM_L2_BANK_PER_ROW 32
+#define MISALIGNED_ADDR 0x04
+#define L2_WRITE_ADDR (PB_L2_BASE_ADDR + MISALIGNED_ADDR)
+
+int main() {
+  volatile uint32_t *l2ptr = (volatile uint32_t *)L2_WRITE_ADDR;
+  volatile uint32_t result;
+
+  // Write TESTVAL to each physical bank:
+  for (int phyBank = 0; phyBank < NUM_L2_BANK_PER_ROW; phyBank++) {
+    for (int logBank = 0; logBank < NUM_L2_LOG_BANKS; logBank++) {
+      l2ptr = (volatile uint32_t *)((uintptr_t)L2_WRITE_ADDR +
+                                    (phyBank << 15) + (logBank << 5));
+      *(l2ptr ) = TESTVAL;
+    }
+  }
+
+  // Read back and verify TESTVAL in each bank:
+  l2ptr = (volatile uint32_t *)L2_WRITE_ADDR;
+  for (int phyBank = 0; phyBank < NUM_L2_BANK_PER_ROW; phyBank++) {
+    for (int logBank = 0; logBank < NUM_L2_LOG_BANKS; logBank++) {
+      l2ptr = (volatile uint32_t *)((uintptr_t)L2_WRITE_ADDR +
+                                    (phyBank << 15) + (logBank << 5));
+      result = *(l2ptr);
+      if (result != TESTVAL) {
+        return 1;
+      }
+    }
+  }
+
+  return 0;
+}

--- a/sw/cheshire/tests/simple_offload.c
+++ b/sw/cheshire/tests/simple_offload.c
@@ -8,15 +8,20 @@
 #include "picobello_addrmap.h"
 
 // This needs to be in a region which is not cached
-volatile uint32_t (*return_code_array)[CFG_CLUSTER_NR_CORES] = (uint32_t (*)[CFG_CLUSTER_NR_CORES])0x14000000;
+volatile uint32_t (*return_code_array)[CFG_CLUSTER_NR_CORES] = (uint32_t (*)[CFG_CLUSTER_NR_CORES])0x30008000;
 
 int main() {
 
   // Write entry point to scratch register 1
   // and return code address to scratch register 0
+  // Initalize return address loaction before offloading.
   for (int i = 0; i < SNRT_CLUSTER_NUM; i++) {
     *(volatile uint32_t *)((uintptr_t)PB_SNITCH_CL_SCRATCH_ADDR(i, 1)) = PB_L2_BASE_ADDR;
-    *(volatile uint32_t *)((uintptr_t)PB_SNITCH_CL_SCRATCH_ADDR(i, 0)) = (uintptr_t)&return_code_array[i];
+    *(volatile uint32_t *)((uintptr_t)PB_SNITCH_CL_SCRATCH_ADDR(i, 0)) =
+        (uintptr_t)&return_code_array[i];
+    for (int j = 0; j < CFG_CLUSTER_NR_CORES; j++) {
+      return_code_array[i][j] = 0;
+    }
   }
 
   // Start all cores by setting the clint interrupt


### PR DESCRIPTION
## Regression Tests
This PR introduces some regression tests. 
All added tests have been added to the CI.

## Addition:
- **access_l2.c**: This test writes to and reads from the physical banks of the L2 memory through Cheshire, ensuring that the host can access the L2 memory.
- **simple_offload.c**: The simple offload test has been modified to use the SoC L2 as a return code address. As a result, Cheshire must first set the return code destination to zero and then read it to verify the actual return code.