### PR TITLE
treewide: Add FhG SPU

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -159,6 +159,12 @@ packages:
       Git: https://github.com/pulp-platform/dram_rtl_sim.git
     dependencies:
     - axi
+  fhg_spu_cluster:
+    revision: null
+    version: null
+    source:
+      Path: deps/fhg_spu_cluster
+    dependencies: []
   floo_noc:
     revision: 6ac187326b222a491180cc3f77e0e4e5a69f5167
     version: 0.6.1

--- a/Bender.yml
+++ b/Bender.yml
@@ -41,9 +41,13 @@ sources:
   # Level 2
   - hw/cluster_tile.sv
   - hw/cheshire_tile.sv
-  - hw/fhg_spu_tile.sv
   - hw/mem_tile.sv
   - hw/dummy_tile.sv
+
+  - target: not(asic)
+    files:
+    - hw/fhg_spu_tile.sv
+
   # Level 3
   - hw/picobello_top.sv
 

--- a/Bender.yml
+++ b/Bender.yml
@@ -17,6 +17,7 @@ dependencies:
   obi: { git: "https://github.com/pulp-platform/obi.git", rev: "ad1d48f025be540344960ea83b4bff39876f9b36"}
   axi_obi: { path: "hw/axi_obi" }
   picobello-pd:  { path: "./pd" }
+  fhg_spu_cluster:  { path: "./deps/fhg_spu_cluster" }
 
 workspace:
   package_links:
@@ -47,6 +48,10 @@ sources:
   - target: not(asic)
     files:
     - hw/fhg_spu_tile.sv
+
+  - target: asic
+    files:
+    - deps/fhg_spu_cluster/hw/fhg_spu_tile.sv
 
   # Level 3
   - hw/picobello_top.sv

--- a/Bender.yml
+++ b/Bender.yml
@@ -41,6 +41,7 @@ sources:
   # Level 2
   - hw/cluster_tile.sv
   - hw/cheshire_tile.sv
+  - hw/fhg_spu_tile.sv
   - hw/mem_tile.sv
   - hw/dummy_tile.sv
   # Level 3

--- a/Makefile
+++ b/Makefile
@@ -99,16 +99,24 @@ floo-clean:
 PD_REMOTE ?= git@iis-git.ee.ethz.ch:picobello/picobello-pd.git
 PD_COMMIT ?= 1c0dd5204bd517cf0d16f7a7169220a06d544443
 PD_DIR = $(PB_ROOT)/pd
+SPU_REMOTE ?= git@iis-git.ee.ethz.ch:picobello/fhg_spu_cluster.git
+SPU_COMMIT ?= 9018001042539fb8919a370de542bf0535f6483a
+SPU_DIR = $(PB_ROOT)/deps/fhg_spu_cluster
 
 .PHONY: init-pd clean-pd
 
-init-pd: $(PD_DIR)
+init-pd: $(PD_DIR) $(SPU_DIR)
 $(PD_DIR):
 	git clone $(PD_REMOTE) $(PD_DIR)
 	cd $(PD_DIR) && git checkout $(PD_COMMIT)
 
+$(SPU_DIR):
+	-git clone $(SPU_REMOTE) $(SPU_DIR)
+	-cd $(SPU_DIR) && git checkout $(SPU_COMMIT)
+
 clean-pd:
 	rm -rf $(PD_DIR)
+	rm -rf $(SPU_DIR)
 
 -include $(PD_DIR)/pd.mk
 

--- a/Makefile
+++ b/Makefile
@@ -97,10 +97,10 @@ floo-clean:
 ###################
 
 PD_REMOTE ?= git@iis-git.ee.ethz.ch:picobello/picobello-pd.git
-PD_COMMIT ?= d3676160037185b556da3eb364b83ac527a73034
+PD_COMMIT ?= 1c0dd5204bd517cf0d16f7a7169220a06d544443
 PD_DIR = $(PB_ROOT)/pd
 SPU_REMOTE ?= git@iis-git.ee.ethz.ch:picobello/fhg_spu_cluster.git
-SPU_COMMIT ?= 52ff92b99d07f7fa48d9b81c5d713c369bd4faa6
+SPU_COMMIT ?= 9018001042539fb8919a370de542bf0535f6483a
 SPU_DIR = $(PB_ROOT)/deps/fhg_spu_cluster
 
 .PHONY: init-pd clean-pd

--- a/Makefile
+++ b/Makefile
@@ -97,10 +97,10 @@ floo-clean:
 ###################
 
 PD_REMOTE ?= git@iis-git.ee.ethz.ch:picobello/picobello-pd.git
-PD_COMMIT ?= 1c0dd5204bd517cf0d16f7a7169220a06d544443
+PD_COMMIT ?= d3676160037185b556da3eb364b83ac527a73034
 PD_DIR = $(PB_ROOT)/pd
 SPU_REMOTE ?= git@iis-git.ee.ethz.ch:picobello/fhg_spu_cluster.git
-SPU_COMMIT ?= 9018001042539fb8919a370de542bf0535f6483a
+SPU_COMMIT ?= 52ff92b99d07f7fa48d9b81c5d713c369bd4faa6
 SPU_DIR = $(PB_ROOT)/deps/fhg_spu_cluster
 
 .PHONY: init-pd clean-pd

--- a/cfg/picobello_noc.yml
+++ b/cfg/picobello_noc.yml
@@ -65,6 +65,16 @@ endpoints:
     sbr_port_protocol:
       - "narrow_out"
       - "wide_out"
+  - name: "fhg_spu"
+    addr_range:
+      - start: 0x4000_0000
+        size: 0x0004_0000
+    mgr_port_protocol:
+      - "narrow_in"
+      - "wide_in"
+    sbr_port_protocol:
+      - "narrow_out"
+      - "wide_out"
   - name: "l2_spm"
     array: [8]
     addr_range:
@@ -92,6 +102,10 @@ connections:
   - src: "cheshire"
     dst: "router"
     dst_idx: [6, 3]
+    dst_dir: "Eject"
+  - src: "fhg_spu"
+    dst: "router"
+    dst_idx: [6, 0]
     dst_dir: "Eject"
   - src: "l2_spm"
     dst: "router"

--- a/hw/fhg_spu_tile.sv
+++ b/hw/fhg_spu_tile.sv
@@ -76,6 +76,6 @@ module fhg_spu_tile
   // It's actually a dummy tile: tie the router’s Eject input ports to 0
   assign router_floo_req_in[Eject]       = '0;
   assign router_floo_rsp_in[Eject]       = '0;
-
+  assign router_floo_wide_in[Eject]      = '0;
 
 endmodule : fhg_spu_tile

--- a/hw/fhg_spu_tile.sv
+++ b/hw/fhg_spu_tile.sv
@@ -1,0 +1,81 @@
+// Copyright 2025 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Riccardo Fiorani Gallotta <riccardo.fiorani3@unibo.it>
+
+`include "axi/assign.svh"
+
+module fhg_spu_tile
+  import floo_pkg::*;
+  import floo_picobello_noc_pkg::*;
+  import picobello_pkg::*;
+(
+  input  logic                                   clk_i,
+  input  logic                                   rst_ni,
+  input  logic                                   test_enable_i,
+  // Cluster ports
+  input  logic                      [       8:0] debug_req_i,
+  input  logic                      [       8:0] meip_i,
+  input  logic                      [       8:0] mtip_i,
+  input  logic                      [       8:0] msip_i,
+  input  logic                      [       9:0] hart_base_id_i,
+  input  snitch_cluster_pkg::addr_t              cluster_base_addr_i,
+  // Chimney ports
+  input  id_t                                    id_i,
+  // Router ports
+  output floo_req_t                 [West:North] floo_req_o,
+  input  floo_rsp_t                 [West:North] floo_rsp_i,
+  output floo_wide_t                [West:North] floo_wide_o,
+  input  floo_req_t                 [West:North] floo_req_i,
+  output floo_rsp_t                 [West:North] floo_rsp_o,
+  input  floo_wide_t                [West:North] floo_wide_i
+);
+
+  ////////////
+  // Router //
+  ////////////
+
+  floo_req_t [Eject:North] router_floo_req_out, router_floo_req_in;
+  floo_rsp_t [Eject:North] router_floo_rsp_out, router_floo_rsp_in;
+  floo_wide_t [Eject:North] router_floo_wide_out, router_floo_wide_in;
+
+  floo_nw_router #(
+    .AxiCfgN     (AxiCfgN),
+    .AxiCfgW     (AxiCfgW),
+    .RouteAlgo   (RouteCfg.RouteAlgo),
+    .NumRoutes   (5),
+    .InFifoDepth (2),
+    .OutFifoDepth(2),
+    .id_t        (id_t),
+    .hdr_t       (hdr_t),
+    .floo_req_t  (floo_req_t),
+    .floo_rsp_t  (floo_rsp_t),
+    .floo_wide_t (floo_wide_t)
+  ) i_router (
+    .clk_i,
+    .rst_ni,
+    .test_enable_i,
+    .id_i,
+    .id_route_map_i('0),
+    .floo_req_i    (router_floo_req_in),
+    .floo_rsp_o    (router_floo_rsp_out),
+    .floo_req_o    (router_floo_req_out),
+    .floo_rsp_i    (router_floo_rsp_in),
+    .floo_wide_i   (router_floo_wide_in),
+    .floo_wide_o   (router_floo_wide_out)
+  );
+
+  assign floo_req_o                      = router_floo_req_out[West:North];
+  assign router_floo_req_in[West:North]  = floo_req_i;
+  assign floo_rsp_o                      = router_floo_rsp_out[West:North];
+  assign router_floo_rsp_in[West:North]  = floo_rsp_i;
+  assign floo_wide_o                     = router_floo_wide_out[West:North];
+  assign router_floo_wide_in[West:North] = floo_wide_i;
+
+  // It's actually a dummy tile: tie the router’s Eject input ports to 0
+  assign router_floo_req_in[Eject]       = '0;
+  assign router_floo_rsp_in[Eject]       = '0;
+
+
+endmodule : fhg_spu_tile

--- a/hw/picobello_top.sv
+++ b/hw/picobello_top.sv
@@ -190,6 +190,7 @@ module picobello_top
 
   localparam id_t FhgSpuId = Sam[FhgSpuSamIdx].idx;
 
+  // TODO: connect actual hart_base_id
   fhg_spu_tile i_fhg_spu_tile (
     .clk_i,
     .rst_ni,
@@ -198,7 +199,7 @@ module picobello_top
     .meip_i             (fhg_spu_meip),
     .mtip_i             (fhg_spu_mtip),
     .msip_i             (fhg_spu_msip),
-    .hart_base_id_i     ('0), //TODO: connect actual hart_base_id
+    .hart_base_id_i     ('0),
     .cluster_base_addr_i(Sam[FhgSpuSamIdx].start_addr),
     .id_i               (FhgSpuId),
     .floo_req_o         (floo_req_out[FhgSpuId.x][FhgSpuId.y]),

--- a/hw/picobello_top.sv
+++ b/hw/picobello_top.sv
@@ -176,6 +176,39 @@ module picobello_top
     .floo_wide_i(floo_wide_in[CheshireId.x][CheshireId.y])
   );
 
+  //////////////////
+  // FhG SPU tile //
+  //////////////////
+
+  // TODO: Connect the debug and interrupt signals
+  logic [8:0] fhg_spu_debug_req, fhg_spu_meip, fhg_spu_mtip, fhg_spu_msip;
+
+  assign fhg_spu_debug_req = '0;
+  assign fhg_spu_meip      = '0;
+  assign fhg_spu_mtip      = '0;
+  assign fhg_spu_msip      = '0;
+
+  localparam id_t FhgSpuId = Sam[FhgSpuSamIdx].idx;
+
+  fhg_spu_tile i_fhg_spu_tile (
+    .clk_i,
+    .rst_ni,
+    .test_enable_i      (test_mode_i),
+    .debug_req_i        (fhg_spu_debug_req),
+    .meip_i             (fhg_spu_meip),
+    .mtip_i             (fhg_spu_mtip),
+    .msip_i             (fhg_spu_msip),
+    .hart_base_id_i     ('0), //TODO: connect actual hart_base_id
+    .cluster_base_addr_i(Sam[FhgSpuSamIdx].start_addr),
+    .id_i               (FhgSpuId),
+    .floo_req_o         (floo_req_out[FhgSpuId.x][FhgSpuId.y]),
+    .floo_rsp_i         (floo_rsp_in[FhgSpuId.x][FhgSpuId.y]),
+    .floo_wide_o        (floo_wide_out[FhgSpuId.x][FhgSpuId.y]),
+    .floo_req_i         (floo_req_in[FhgSpuId.x][FhgSpuId.y]),
+    .floo_rsp_o         (floo_rsp_out[FhgSpuId.x][FhgSpuId.y]),
+    .floo_wide_i        (floo_wide_in[FhgSpuId.x][FhgSpuId.y])
+  );
+
   //////////////
   // Mem tile //
   //////////////


### PR DESCRIPTION
Adds FhG SPU rtl to the repo.

In summary:

- Instantiates the `fhg_spu_tile` module in the `picobello_top`
- Adds it to the floonoc configuration file
- Adds a dummy tile for rtl compilation without asic target
- Adds a local dependency in Bender.yml
- Edits the make file to clone the SPU rtl from private repo (like for PD repo)
- Updates the PD repo commit