### PR TITLE
Replace AXI atomic adapter with OBI atomic adapter

### DIFF
--- a/.gitlab/common.yml
+++ b/.gitlab/common.yml
@@ -59,6 +59,7 @@
     - .init-env
   script:
     - make sn-tests
+    - make pb-sn-tests
   artifacts:
     paths:
       - sw/snitch/tests/build/*.elf

--- a/.gitlab/sw-tests.yml
+++ b/.gitlab/sw-tests.yml
@@ -19,3 +19,4 @@
       - { CHS_BINARY: $CHS_BUILD_DIR/simple_offload.spm.elf, SN_BINARY: $SN_BUILD_DIR/simple.elf, PRELMODE: 1 }
       # - { CHS_BINARY: $CHS_BUILD_DIR/simple_offload.spm.elf, SN_BINARY: $SN_BUILD_DIR/simple.elf, PRELMODE: 3 }
       - { CHS_BINARY: $CHS_BUILD_DIR/simple_offload.spm.elf, SN_BINARY: $SN_BUILD_DIR/non_null_exitcode.elf, NZ_EXIT_CODE: 896 }
+      - { CHS_BINARY: $CHS_BUILD_DIR/simple_offload.spm.elf, SN_BINARY: $SN_BUILD_DIR/multicluster_atomics.elf }

--- a/Bender.lock
+++ b/Bender.lock
@@ -207,8 +207,8 @@ packages:
     - common_cells
     - register_interface
   obi:
-    revision: 8097928cf1b43712f93d5356f336397879b4ad2c
-    version: 0.1.6
+    revision: ad1d48f025be540344960ea83b4bff39876f9b36
+    version: null
     source:
       Git: https://github.com/pulp-platform/obi.git
     dependencies:

--- a/Bender.lock
+++ b/Bender.lock
@@ -34,6 +34,15 @@ packages:
     - common_verification
     - register_interface
     - tech_cells_generic
+  axi_obi:
+    revision: null
+    version: null
+    source:
+      Path: hw/axi_obi
+    dependencies:
+    - axi
+    - common_cells
+    - obi
   axi_riscv_atomics:
     revision: 0ac3a78fe342c5a5b9b10bff49d58897f773059e
     version: 0.8.2

--- a/Bender.yml
+++ b/Bender.yml
@@ -14,6 +14,7 @@ dependencies:
   cheshire: { git: "https://github.com/pulp-platform/cheshire.git", rev: "main" }
   floo_noc: { git: "https://github.com/pulp-platform/FlooNoC.git", version: "0.6.1"}
   snitch_cluster: { git: "https://github.com/pulp-platform/snitch_cluster.git", rev: "main" }
+  axi_obi: { path: "hw/axi_obi" }
   picobello-pd:  { path: "./pd" }
 
 workspace:

--- a/Bender.yml
+++ b/Bender.yml
@@ -14,6 +14,7 @@ dependencies:
   cheshire: { git: "https://github.com/pulp-platform/cheshire.git", rev: "main" }
   floo_noc: { git: "https://github.com/pulp-platform/FlooNoC.git", version: "0.6.1"}
   snitch_cluster: { git: "https://github.com/pulp-platform/snitch_cluster.git", rev: "main" }
+  obi: { git: "https://github.com/pulp-platform/obi.git", rev: "ad1d48f025be540344960ea83b4bff39876f9b36"}
   axi_obi: { path: "hw/axi_obi" }
   picobello-pd:  { path: "./pd" }
 

--- a/hw/axi_obi/Bender.yml
+++ b/hw/axi_obi/Bender.yml
@@ -1,0 +1,18 @@
+# Copyright 2023 ETH Zurich and University of Bologna.
+# Solderpad Hardware License, Version 0.51, see LICENSE for details.
+# SPDX-License-Identifier: SHL-0.51
+
+package:
+  name: axi_obi
+  authors:
+    - "Michael Rogenmoser <michaero@iis.ee.ethz.ch>"
+
+dependencies:
+  axi:          { git: "https://github.com/pulp-platform/axi.git",          version: 0.39.1 }
+  obi:          { git: "https://github.com/pulp-platform/obi.git",          version: 0.1.1  }
+  common_cells: { git: "https://github.com/pulp-platform/common_cells.git", version: 1.31.1 }
+
+sources:
+  - src/axi_to_detailed_mem_user.sv
+  - src/axi_to_obi.sv
+  - src/obi_to_axi.sv

--- a/hw/axi_obi/Bender.yml
+++ b/hw/axi_obi/Bender.yml
@@ -9,7 +9,7 @@ package:
 
 dependencies:
   axi:          { git: "https://github.com/pulp-platform/axi.git",          version: 0.39.1 }
-  obi:          { git: "https://github.com/pulp-platform/obi.git",          version: 0.1.1  }
+  obi:          { git: "https://github.com/pulp-platform/obi.git",rev: "ad1d48f025be540344960ea83b4bff39876f9b36"}
   common_cells: { git: "https://github.com/pulp-platform/common_cells.git", version: 1.31.1 }
 
 sources:

--- a/hw/axi_obi/Readme.md
+++ b/hw/axi_obi/Readme.md
@@ -1,0 +1,3 @@
+# AXI - OBI protocol converters
+
+Protocol converters for the pulp-platform OBI and AXI IPs.

--- a/hw/axi_obi/src/axi_to_detailed_mem_user.sv
+++ b/hw/axi_obi/src/axi_to_detailed_mem_user.sv
@@ -1,0 +1,655 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Authors:
+// - Michael Rogenmoser <michaero@iis.ee.ethz.ch>
+// - Thomas Benz <tbenz@iis.ee.ethz.ch>
+
+`include "common_cells/registers.svh"
+/// AXI4+ATOP slave module which translates AXI bursts into a memory stream.
+/// If both read and write channels of the AXI4+ATOP are active, both will have an
+/// utilization of 50%.
+module axi_to_detailed_mem_user #(
+  /// AXI4+ATOP request type. See `include/axi/typedef.svh`.
+  parameter type         axi_req_t  = logic,
+  /// AXI4+ATOP response type. See `include/axi/typedef.svh`.
+  parameter type         axi_resp_t = logic,
+  /// Address width, has to be less or equal than the width off the AXI address field.
+  /// Determines the width of `mem_addr_o`. Has to be wide enough to emit the memory region
+  /// which should be accessible.
+  parameter int unsigned AddrWidth  = 0,
+  /// AXI4+ATOP data width.
+  parameter int unsigned DataWidth  = 0,
+  /// AXI4+ATOP ID width.
+  parameter int unsigned IdWidth    = 0,
+  /// AXI4+ATOP user width.
+  parameter int unsigned UserWidth  = 0,
+  /// Number of banks at output, must evenly divide `DataWidth`.
+  parameter int unsigned NumBanks   = 0,
+  /// Depth of memory response buffer. This should be equal to the memory response latency.
+  parameter int unsigned BufDepth   = 1,
+  /// Hide write requests if the strb == '0
+  parameter bit          HideStrb   = 1'b0,
+  /// Depth of output fifo/fall_through_register. Increase for asymmetric backpressure (contention) on banks.
+  parameter int unsigned OutFifoDepth = 1,
+  /// Prepend W user to `mem_user_o`.
+  parameter bit          PropagateWUser = 1'b0,
+  /// Additional Signals for ruser calculation Width.
+  parameter int unsigned RUserExtra = 1,
+  /// Dependent parameter, do not override. Memory address type.
+  localparam type addr_t     = logic [AddrWidth-1:0],
+  /// Dependent parameter, do not override. Memory data type.
+  localparam type mem_data_t = logic [DataWidth/NumBanks-1:0],
+  /// Dependent parameter, do not override. Memory write strobe type.
+  localparam type mem_strb_t = logic [DataWidth/NumBanks/8-1:0],
+  /// Dependent parameter, do not override. Memory id type.
+  localparam type mem_id_t   = logic [IdWidth-1:0],
+  /// Dependent parameter, do not override. Memory user type.
+  localparam type mem_user_t = logic [UserWidth+(PropagateWUser ? UserWidth : 0)-1:0]
+) (
+  /// Clock input.
+  input  logic                             clk_i,
+  /// Asynchronous reset, active low.
+  input  logic                             rst_ni,
+  /// The unit is busy handling an AXI4+ATOP request.
+  output logic                             busy_o,
+  /// AXI4+ATOP slave port, request input.
+  input  axi_req_t                         axi_req_i,
+  /// AXI4+ATOP slave port, response output.
+  output axi_resp_t                        axi_resp_o,
+  /// Memory stream master, request is valid for this bank.
+  output logic             [NumBanks-1:0]  mem_req_o,
+  /// Memory stream master, request can be granted by this bank.
+  input  logic             [NumBanks-1:0]  mem_gnt_i,
+  /// Memory stream master, byte address of the request.
+  output addr_t            [NumBanks-1:0]  mem_addr_o,
+  /// Memory stream master, write data for this bank. Valid when `mem_req_o`.
+  output mem_data_t        [NumBanks-1:0]  mem_wdata_o,
+  /// Memory stream master, byte-wise strobe (byte enable).
+  output mem_strb_t        [NumBanks-1:0]  mem_strb_o,
+  /// Memory stream master, `axi_pkg::atop_t` signal associated with this request.
+  output axi_pkg::atop_t   [NumBanks-1:0]  mem_atop_o,
+  /// Memory stream master, lock signal.
+  output logic             [NumBanks-1:0]  mem_lock_o,
+  /// Memory stream master, write enable. Then asserted store of `mem_w_data` is requested.
+  output logic             [NumBanks-1:0]  mem_we_o,
+  /// Memory stream master, ID. Response ID is managed internally, ensure in-order responses.
+  output mem_id_t          [NumBanks-1:0]  mem_id_o,
+  /// Memory stream master, user signal. Ax channel user bits used.
+  output mem_user_t        [NumBanks-1:0]  mem_user_o,
+  /// Memory stream master, cache signal.
+  output axi_pkg::cache_t  [NumBanks-1:0]  mem_cache_o,
+  /// Memory stream master, protection signal.
+  output axi_pkg::prot_t   [NumBanks-1:0]  mem_prot_o,
+  /// Memory stream master, QOS signal.
+  output axi_pkg::qos_t    [NumBanks-1:0]  mem_qos_o,
+  /// Memory stream master, region signal.
+  output axi_pkg::region_t [NumBanks-1:0]  mem_region_o,
+  /// Memory stream master, response is valid. This module expects always a response valid for a
+  /// request regardless if the request was a write or a read.
+  input  logic             [NumBanks-1:0]  mem_rvalid_i,
+  /// Memory stream master, read response data.
+  input  mem_data_t        [NumBanks-1:0]  mem_rdata_i,
+  /// Memory stream master, error response.
+  input  logic             [NumBanks-1:0]  mem_err_i,
+  /// Memory stream master, read response exclusive access OK.
+  input  logic             [NumBanks-1:0]  mem_exokay_i,
+  /// Memory stream master, response custom signals for ruser calculation.
+  input  logic [NumBanks-1:0][RUserExtra-1:0]  mem_ruser_i,
+  /// Signals for response user signal collection
+  output mem_user_t                           ruser_req_user_o,
+  output logic [NumBanks-1:0]                 ruser_req_bank_strb_o,
+  output logic [NumBanks-1:0]                 ruser_req_size_enable_o,
+  output logic [NumBanks-1:0][RUserExtra-1:0] ruser_rsp_extra_o,
+  output logic                                ruser_req_write_o,
+  output logic                                ruser_req_last_o,
+  output logic                                ruser_rsp_hs_o,
+  input  logic [UserWidth-1:0]                ruser_i
+);
+
+  typedef logic [DataWidth-1:0]   axi_data_t;
+  typedef logic [DataWidth/8-1:0] axi_strb_t;
+  typedef logic [IdWidth-1:0]     axi_id_t;
+
+  typedef struct packed {
+    addr_t            addr;
+    axi_pkg::atop_t   atop;
+    logic             lock;
+    axi_strb_t        strb;
+    axi_data_t        wdata;
+    logic             we;
+    mem_id_t          id;
+    mem_user_t        user;
+    axi_pkg::cache_t  cache;
+    axi_pkg::prot_t   prot;
+    axi_pkg::qos_t    qos;
+    axi_pkg::region_t region;
+  } mem_req_t;
+
+  typedef struct packed {
+    addr_t            addr;
+    axi_pkg::atop_t   atop;
+    logic             lock;
+    axi_strb_t        strb;
+    axi_id_t          id;
+    logic             last;
+    axi_pkg::qos_t    qos;
+    axi_pkg::size_t   size;
+    logic             write;
+    mem_user_t        user;
+    axi_pkg::cache_t  cache;
+    axi_pkg::prot_t   prot;
+    axi_pkg::region_t region;
+  } meta_t;
+
+  typedef struct packed {
+    axi_data_t           data;
+    logic [NumBanks-1:0] err;
+    logic [NumBanks-1:0] exokay;
+    logic [NumBanks-1:0][RUserExtra-1:0] ruser;
+  } mem_rsp_t;
+
+  mem_rsp_t       mem_rdata,
+                  m2s_resp;
+  axi_pkg::len_t  r_cnt_d,        r_cnt_q,
+                  w_cnt_d,        w_cnt_q;
+  logic           arb_valid,      arb_ready,
+                  rd_valid,       rd_ready,
+                  wr_valid,       wr_ready,
+                  sel_b,          sel_buf_b,
+                  sel_r,          sel_buf_r,
+                  sel_valid,      sel_ready,
+                  sel_buf_valid,  sel_buf_ready,
+                  sel_lock_d,     sel_lock_q,
+                  meta_valid,     meta_ready,
+                  meta_buf_valid, meta_buf_ready,
+                  meta_sel_d,     meta_sel_q,
+                  m2s_req_valid,  m2s_req_ready,
+                  m2s_resp_valid, m2s_resp_ready,
+                  mem_req_valid,  mem_req_ready,
+                  mem_rvalid;
+  mem_req_t       m2s_req,
+                  mem_req;
+  meta_t          rd_meta,
+                  rd_meta_d,      rd_meta_q,
+                  wr_meta,
+                  wr_meta_d,      wr_meta_q,
+                  meta,           meta_buf;
+
+  assign busy_o = axi_req_i.aw_valid | axi_req_i.ar_valid | axi_req_i.w_valid |
+                    axi_resp_o.b_valid | axi_resp_o.r_valid |
+                    (r_cnt_q > 0) | (w_cnt_q > 0);
+
+  // Handle reads.
+  always_comb begin
+    // Default assignments
+    axi_resp_o.ar_ready = 1'b0;
+    rd_meta_d           = rd_meta_q;
+    rd_meta             = meta_t'{default: '0};
+    rd_valid            = 1'b0;
+    r_cnt_d             = r_cnt_q;
+    // Handle R burst in progress.
+    if (r_cnt_q > '0) begin
+      rd_meta_d.last = (r_cnt_q == 8'd1);
+      rd_meta        = rd_meta_d;
+      rd_meta.addr   = rd_meta_q.addr + axi_pkg::num_bytes(rd_meta_q.size);
+      rd_valid       = 1'b1;
+      if (rd_ready) begin
+        r_cnt_d--;
+        rd_meta_d.addr = rd_meta.addr;
+      end
+    // Handle new AR if there is one.
+    end else if (axi_req_i.ar_valid) begin
+      rd_meta_d = '{
+        addr:   addr_t'(axi_pkg::aligned_addr(axi_req_i.ar.addr, axi_req_i.ar.size)),
+        atop:   '0,
+        lock:   axi_req_i.ar.lock,
+        strb:   '0,
+        id:     axi_req_i.ar.id,
+        last:   (axi_req_i.ar.len == '0),
+        qos:    axi_req_i.ar.qos,
+        size:   axi_req_i.ar.size,
+        write:  1'b0,
+        user:   (PropagateWUser ? {{UserWidth{1'b0}}, axi_req_i.ar.user} : axi_req_i.ar.user),
+        cache:  axi_req_i.ar.cache,
+        prot:   axi_req_i.ar.prot,
+        region: axi_req_i.ar.region
+      };
+      rd_meta      = rd_meta_d;
+      rd_meta.addr = addr_t'(axi_req_i.ar.addr);
+      rd_valid     = 1'b1;
+      if (rd_ready) begin
+        r_cnt_d             = axi_req_i.ar.len;
+        axi_resp_o.ar_ready = 1'b1;
+      end
+    end
+  end
+
+  // Handle writes.
+  always_comb begin
+    // Default assignments
+    axi_resp_o.aw_ready = 1'b0;
+    axi_resp_o.w_ready  = 1'b0;
+    wr_meta_d           = wr_meta_q;
+    wr_meta             = meta_t'{default: '0};
+    wr_valid            = 1'b0;
+    w_cnt_d             = w_cnt_q;
+    // Handle W bursts in progress.
+    if (w_cnt_q > '0) begin
+      wr_meta_d.last = (w_cnt_q == 8'd1);
+      wr_meta        = wr_meta_d;
+      wr_meta.addr   = wr_meta_q.addr + axi_pkg::num_bytes(wr_meta_q.size);
+      if (axi_req_i.w_valid) begin
+        wr_valid = 1'b1;
+        wr_meta.strb = axi_req_i.w.strb;
+        if (PropagateWUser) begin
+          wr_meta.user = {axi_req_i.w.user, wr_meta.user[UserWidth-1:0]};
+        end
+        if (wr_ready) begin
+          axi_resp_o.w_ready = 1'b1;
+          w_cnt_d--;
+          wr_meta_d.addr = wr_meta.addr;
+        end
+      end
+    // Handle new AW if there is one.
+    end else if (axi_req_i.aw_valid && axi_req_i.w_valid) begin
+      wr_meta_d = '{
+        addr:   addr_t'(axi_pkg::aligned_addr(axi_req_i.aw.addr, axi_req_i.aw.size)),
+        atop:   axi_req_i.aw.atop,
+        lock:   axi_req_i.aw.lock,
+        strb:   axi_req_i.w.strb,
+        id:     axi_req_i.aw.id,
+        last:   (axi_req_i.aw.len == '0),
+        qos:    axi_req_i.aw.qos,
+        size:   axi_req_i.aw.size,
+        write:  1'b1,
+        user:   PropagateWUser ? {axi_req_i.w.user, axi_req_i.aw.user} : axi_req_i.aw.user,
+        cache:  axi_req_i.aw.cache,
+        prot:   axi_req_i.aw.prot,
+        region: axi_req_i.aw.region
+      };
+      wr_meta = wr_meta_d;
+      wr_meta.addr = addr_t'(axi_req_i.aw.addr);
+      wr_valid = 1'b1;
+      if (wr_ready) begin
+        w_cnt_d = axi_req_i.aw.len;
+        axi_resp_o.aw_ready = 1'b1;
+        axi_resp_o.w_ready = 1'b1;
+      end
+    end
+  end
+
+  // Arbitrate between reads and writes.
+  stream_mux #(
+    .DATA_T ( meta_t ),
+    .N_INP  ( 32'd2  )
+  ) i_ax_mux (
+    .inp_data_i   ({wr_meta,  rd_meta }),
+    .inp_valid_i  ({wr_valid, rd_valid}),
+    .inp_ready_o  ({wr_ready, rd_ready}),
+    .inp_sel_i    ( meta_sel_d         ),
+    .oup_data_o   ( meta               ),
+    .oup_valid_o  ( arb_valid          ),
+    .oup_ready_i  ( arb_ready          )
+  );
+  always_comb begin
+    meta_sel_d = meta_sel_q;
+    sel_lock_d = sel_lock_q;
+    if (sel_lock_q) begin
+      meta_sel_d = meta_sel_q;
+      if (arb_valid && arb_ready) begin
+        sel_lock_d = 1'b0;
+      end
+    end else begin
+      if (wr_valid ^ rd_valid) begin
+        // If either write or read is valid but not both, select the valid one.
+        meta_sel_d = wr_valid;
+      end else if (wr_valid && rd_valid) begin
+        // If both write and read are valid, decide according to QoS then burst properties.
+        // Prioritize higher QoS.
+        if (wr_meta.qos > rd_meta.qos) begin
+          meta_sel_d = 1'b1;
+        end else if (rd_meta.qos > wr_meta.qos) begin
+          meta_sel_d = 1'b0;
+        // Decide requests with identical QoS.
+        end else if (wr_meta.qos == rd_meta.qos) begin
+          // 1. Prioritize individual writes over read bursts.
+          // Rationale: Read bursts can be interleaved on AXI but write bursts cannot.
+          if (wr_meta.last && !rd_meta.last) begin
+            meta_sel_d = 1'b1;
+          // 2. Prioritize ongoing burst.
+          // Rationale: Stalled bursts create back-pressure or require costly buffers.
+          end else if (w_cnt_q > '0) begin
+            meta_sel_d = 1'b1;
+          end else if (r_cnt_q > '0) begin
+            meta_sel_d = 1'b0;
+          // 3. Otherwise arbitrate round robin to prevent starvation.
+          end else begin
+            meta_sel_d = ~meta_sel_q;
+          end
+        end
+      end
+      // Lock arbitration if valid but not yet ready.
+      if (arb_valid && !arb_ready) begin
+        sel_lock_d = 1'b1;
+      end
+    end
+  end
+
+  // Fork arbitrated stream to meta data, memory requests, and R/B channel selection.
+  stream_fork #(
+    .N_OUP ( 32'd3 )
+  ) i_fork (
+    .clk_i,
+    .rst_ni,
+    .valid_i ( arb_valid                            ),
+    .ready_o ( arb_ready                            ),
+    .valid_o ({sel_valid, meta_valid, m2s_req_valid}),
+    .ready_i ({sel_ready, meta_ready, m2s_req_ready})
+  );
+
+  assign sel_b = meta.write & meta.last;
+  assign sel_r = ~meta.write | meta.atop[5];
+
+  stream_fifo #(
+    .FALL_THROUGH ( 1'b1             ),
+    .DEPTH        ( 32'd1 + BufDepth ),
+    .T            ( logic[1:0]       )
+  ) i_sel_buf (
+    .clk_i,
+    .rst_ni,
+    .flush_i    ( 1'b0                    ),
+    .testmode_i ( 1'b0                    ),
+    .data_i     ({sel_b,        sel_r    }),
+    .valid_i    ( sel_valid               ),
+    .ready_o    ( sel_ready               ),
+    .data_o     ({sel_buf_b,    sel_buf_r}),
+    .valid_o    ( sel_buf_valid           ),
+    .ready_i    ( sel_buf_ready           ),
+    .usage_o    ( /* unused */            )
+  );
+
+  stream_fifo #(
+    .FALL_THROUGH ( 1'b1             ),
+    .DEPTH        ( 32'd1 + BufDepth ),
+    .T            ( meta_t           )
+  ) i_meta_buf (
+    .clk_i,
+    .rst_ni,
+    .flush_i    ( 1'b0           ),
+    .testmode_i ( 1'b0           ),
+    .data_i     ( meta           ),
+    .valid_i    ( meta_valid     ),
+    .ready_o    ( meta_ready     ),
+    .data_o     ( meta_buf       ),
+    .valid_o    ( meta_buf_valid ),
+    .ready_i    ( meta_buf_ready ),
+    .usage_o    ( /* unused */   )
+  );
+
+  // Assemble the actual memory request from meta information and write data.
+  assign m2s_req = mem_req_t'{
+    addr:   meta.addr,
+    atop:   meta.atop,
+    lock:   meta.lock,
+    strb:   axi_req_i.w.strb,
+    wdata:  axi_req_i.w.data,
+    we:     meta.write,
+    id:     meta.id,
+    user:   meta.user,
+    cache:  meta.cache,
+    prot:   meta.prot,
+    qos:    meta.qos,
+    region: meta.region
+  };
+
+  // Interface memory as stream.
+  stream_to_mem #(
+    .mem_req_t  ( mem_req_t  ),
+    .mem_resp_t ( mem_rsp_t  ),
+    .BufDepth   ( BufDepth   )
+  ) i_stream_to_mem (
+    .clk_i,
+    .rst_ni,
+    .req_i            ( m2s_req        ),
+    .req_valid_i      ( m2s_req_valid  ),
+    .req_ready_o      ( m2s_req_ready  ),
+    .resp_o           ( m2s_resp       ),
+    .resp_valid_o     ( m2s_resp_valid ),
+    .resp_ready_i     ( m2s_resp_ready ),
+    .mem_req_o        ( mem_req        ),
+    .mem_req_valid_o  ( mem_req_valid  ),
+    .mem_req_ready_i  ( mem_req_ready  ),
+    .mem_resp_i       ( mem_rdata      ),
+    .mem_resp_valid_i ( mem_rvalid     )
+  );
+
+  typedef struct packed {
+    axi_pkg::atop_t   atop;
+    logic             lock;
+    mem_id_t          id;
+    mem_user_t        user;
+    axi_pkg::cache_t  cache;
+    axi_pkg::prot_t   prot;
+    axi_pkg::qos_t    qos;
+    axi_pkg::region_t region;
+  } tmp_atop_t;
+
+  tmp_atop_t mem_req_atop;
+  tmp_atop_t [NumBanks-1:0] banked_req_atop;
+
+  assign mem_req_atop = '{
+    atop:   mem_req.atop,
+    lock:   mem_req.lock,
+    id:     mem_req.id,
+    user:   mem_req.user,
+    cache:  mem_req.cache,
+    prot:   mem_req.prot,
+    qos:    mem_req.qos,
+    region: mem_req.region
+  };
+
+  for (genvar i = 0; i < NumBanks; i++) begin : gen_atop_assign
+    assign mem_atop_o  [i] = banked_req_atop[i].atop;
+    assign mem_lock_o  [i] = banked_req_atop[i].lock;
+    assign mem_id_o    [i] = banked_req_atop[i].id;
+    assign mem_user_o  [i] = banked_req_atop[i].user;
+    assign mem_cache_o [i] = banked_req_atop[i].cache;
+    assign mem_prot_o  [i] = banked_req_atop[i].prot;
+    assign mem_qos_o   [i] = banked_req_atop[i].qos;
+    assign mem_region_o[i] = banked_req_atop[i].region;
+  end
+
+  logic [NumBanks-1:0][RUserExtra+2-1:0] tmp_ersp, bank_ersp;
+  for (genvar i = 0; i < NumBanks; i++) begin : gen_err_assign
+    assign mem_rdata.err[i]    = tmp_ersp[i][0];
+    assign mem_rdata.exokay[i] = tmp_ersp[i][1];
+    assign mem_rdata.ruser[i]  = tmp_ersp[i][RUserExtra+2-1:2];
+    assign bank_ersp[i][0] = mem_err_i[i];
+    assign bank_ersp[i][1] = mem_exokay_i[i];
+    assign bank_ersp[i][RUserExtra+2-1:2] = mem_ruser_i[i];
+  end
+
+  // Split single memory request to desired number of banks.
+  mem_to_banks_detailed #(
+    .AddrWidth  ( AddrWidth         ),
+    .DataWidth  ( DataWidth         ),
+    .RUserWidth ( RUserExtra+2      ),
+    .NumBanks   ( NumBanks          ),
+    .HideStrb   ( HideStrb          ),
+    .MaxTrans   ( BufDepth          ),
+    .FifoDepth  ( OutFifoDepth      ),
+    .WUserWidth ( $bits(tmp_atop_t) )
+  ) i_mem_to_banks (
+    .clk_i,
+    .rst_ni,
+    .req_i         ( mem_req_valid ),
+    .gnt_o         ( mem_req_ready ),
+    .addr_i        ( mem_req.addr  ),
+    .wdata_i       ( mem_req.wdata ),
+    .strb_i        ( mem_req.strb  ),
+    .wuser_i       ( mem_req_atop  ),
+    .we_i          ( mem_req.we    ),
+    .rvalid_o      ( mem_rvalid    ),
+    .rdata_o       ( mem_rdata.data ),
+    .ruser_o       ( tmp_ersp      ),
+    .bank_req_o    ( mem_req_o     ),
+    .bank_gnt_i    ( mem_gnt_i     ),
+    .bank_addr_o   ( mem_addr_o    ),
+    .bank_wdata_o  ( mem_wdata_o   ),
+    .bank_strb_o   ( mem_strb_o    ),
+    .bank_wuser_o  ( banked_req_atop ),
+    .bank_we_o     ( mem_we_o      ),
+    .bank_rvalid_i ( mem_rvalid_i  ),
+    .bank_rdata_i  ( mem_rdata_i   ),
+    .bank_ruser_i  ( bank_ersp     )
+  );
+
+  // Join memory read data and meta data stream.
+  logic mem_join_valid, mem_join_ready;
+  stream_join #(
+    .N_INP ( 32'd2 )
+  ) i_join (
+    .inp_valid_i  ({m2s_resp_valid, meta_buf_valid}),
+    .inp_ready_o  ({m2s_resp_ready, meta_buf_ready}),
+    .oup_valid_o  ( mem_join_valid                 ),
+    .oup_ready_i  ( mem_join_ready                 )
+  );
+
+  // Dynamically fork the joined stream to B and R channels.
+  stream_fork_dynamic #(
+    .N_OUP ( 32'd2 )
+  ) i_fork_dynamic (
+    .clk_i,
+    .rst_ni,
+    .valid_i      ( mem_join_valid                         ),
+    .ready_o      ( mem_join_ready                         ),
+    .sel_i        ({sel_buf_b,          sel_buf_r         }),
+    .sel_valid_i  ( sel_buf_valid                          ),
+    .sel_ready_o  ( sel_buf_ready                          ),
+    .valid_o      ({axi_resp_o.b_valid, axi_resp_o.r_valid}),
+    .ready_i      ({axi_req_i.b_ready,  axi_req_i.r_ready })
+  );
+
+  localparam int unsigned NumBytesPerBank = DataWidth/NumBanks/8;
+
+  logic [NumBanks-1:0] meta_buf_bank_strb, meta_buf_size_enable;
+  logic resp_b_err, resp_b_exokay, resp_r_err, resp_r_exokay;
+
+  // Collect `err` and `exokay` from all banks
+  // To ensure correct propagation, `err` is grouped with `OR` and `exokay` is grouped with `AND`.
+  for (genvar i = 0; i < NumBanks; i++) begin : gen_meta_buf
+    // Set active write banks based on strobe
+    assign meta_buf_bank_strb[i] = |meta_buf.strb[i*NumBytesPerBank +: NumBytesPerBank];
+    // Set active read banks based on size and address offset:
+    //                 (bank.end > addr) && (bank.start < addr+size)
+    assign meta_buf_size_enable[i] =
+           ((i*NumBytesPerBank + NumBytesPerBank) > (meta_buf.addr % DataWidth/8)) &&
+           ((i*NumBytesPerBank) < ((meta_buf.addr % DataWidth/8) + 1<<meta_buf.size));
+  end
+  // Ensure only active banks are used
+  assign resp_b_err    = |(m2s_resp.err    &  meta_buf_bank_strb);   // strobe
+  assign resp_b_exokay = &(m2s_resp.exokay | ~meta_buf_bank_strb);   // strobe
+  assign resp_r_err    = |(m2s_resp.err    &  meta_buf_size_enable); // size & addr offset
+  assign resp_r_exokay = &(m2s_resp.exokay | ~meta_buf_size_enable); // size & addr offset
+
+  logic collect_b_err_d, collect_b_err_q;
+  logic collect_b_exokay_d, collect_b_exokay_q;
+  logic next_collect_b_err, next_collect_b_exokay;
+
+  // Accumulate write errors for single B response
+  // To ensure correct propagation, `err` is grouped with `OR` and `exokay` is grouped with `AND`.
+  assign next_collect_b_err = collect_b_err_q | resp_b_err;
+  assign next_collect_b_exokay = collect_b_exokay_q & resp_b_exokay;
+
+  always_comb begin
+    // By default we keep the previous value
+    collect_b_err_d = collect_b_err_q;
+    collect_b_exokay_d = collect_b_exokay_q;
+    // If the buffer is properly popped
+    if (sel_buf_valid && sel_buf_ready) begin
+      if (meta_buf.write && meta_buf.last) begin
+        collect_b_err_d = 1'b0;
+        collect_b_exokay_d = 1'b1;
+      end else if (meta_buf.write) begin
+        collect_b_err_d = next_collect_b_err;
+        collect_b_exokay_d = next_collect_b_exokay;
+      end
+    end
+  end
+
+  // Compose B responses.
+  assign axi_resp_o.b = '{
+    id:   meta_buf.id,
+    resp: next_collect_b_err ?
+          axi_pkg::RESP_SLVERR :
+          next_collect_b_exokay ? axi_pkg::RESP_EXOKAY : axi_pkg::RESP_OKAY,
+    user: ruser_i
+  };
+
+  // Compose R responses.
+  assign axi_resp_o.r = '{
+    data: m2s_resp.data,
+    id:   meta_buf.id,
+    last: meta_buf.last,
+    resp: resp_r_err ?
+          axi_pkg::RESP_SLVERR :
+          resp_r_exokay ? axi_pkg::RESP_EXOKAY : axi_pkg::RESP_OKAY,
+    user: ruser_i
+  };
+
+  assign ruser_req_user_o        = meta_buf.user;
+  assign ruser_req_bank_strb_o   = meta_buf_bank_strb;
+  assign ruser_req_size_enable_o = meta_buf_size_enable;
+  assign ruser_req_write_o       = meta_buf.write;
+  assign ruser_req_last_o        = meta_buf.last;
+  assign ruser_rsp_hs_o          = sel_buf_valid && sel_buf_ready;
+  assign ruser_rsp_extra_o       = m2s_resp.ruser;
+
+  // Registers
+  `FFARN(meta_sel_q, meta_sel_d, 1'b0, clk_i, rst_ni)
+  `FFARN(sel_lock_q, sel_lock_d, 1'b0, clk_i, rst_ni)
+  `FFARN(rd_meta_q, rd_meta_d, meta_t'{default: '0}, clk_i, rst_ni)
+  `FFARN(wr_meta_q, wr_meta_d, meta_t'{default: '0}, clk_i, rst_ni)
+  `FFARN(r_cnt_q, r_cnt_d, '0, clk_i, rst_ni)
+  `FFARN(w_cnt_q, w_cnt_d, '0, clk_i, rst_ni)
+  `FFARN(collect_b_err_q, collect_b_err_d, '0, clk_i, rst_ni)
+  `FFARN(collect_b_exokay_q, collect_b_exokay_d, 1'b1, clk_i, rst_ni)
+
+  // Assertions
+  // pragma translate_off
+  `ifndef VERILATOR
+  default disable iff (!rst_ni);
+  assume property (@(posedge clk_i)
+      axi_req_i.ar_valid && !axi_resp_o.ar_ready |=> $stable(axi_req_i.ar))
+    else $error("AR must remain stable until handshake has happened!");
+  assert property (@(posedge clk_i)
+      axi_resp_o.r_valid && !axi_req_i.r_ready |=> $stable(axi_resp_o.r))
+    else $error("R must remain stable until handshake has happened!");
+  assume property (@(posedge clk_i)
+      axi_req_i.aw_valid && !axi_resp_o.aw_ready |=> $stable(axi_req_i.aw))
+    else $error("AW must remain stable until handshake has happened!");
+  assume property (@(posedge clk_i)
+      axi_req_i.w_valid && !axi_resp_o.w_ready |=> $stable(axi_req_i.w))
+    else $error("W must remain stable until handshake has happened!");
+  assert property (@(posedge clk_i)
+      axi_resp_o.b_valid && !axi_req_i.b_ready |=> $stable(axi_resp_o.b))
+    else $error("B must remain stable until handshake has happened!");
+  assert property (@(posedge clk_i) axi_req_i.ar_valid && axi_req_i.ar.len > 0 |->
+      axi_req_i.ar.burst == axi_pkg::BURST_INCR)
+    else $error("Non-incrementing bursts are not supported!");
+  assert property (@(posedge clk_i) axi_req_i.aw_valid && axi_req_i.aw.len > 0 |->
+      axi_req_i.aw.burst == axi_pkg::BURST_INCR)
+    else $error("Non-incrementing bursts are not supported!");
+  assert property (@(posedge clk_i) meta_valid && meta.atop != '0 |-> meta.write)
+    else $warning("Unexpected atomic operation on read.");
+  `endif
+  // pragma translate_on
+endmodule

--- a/hw/axi_obi/src/axi_to_detailed_mem_user.sv
+++ b/hw/axi_obi/src/axi_to_detailed_mem_user.sv
@@ -1,12 +1,6 @@
-// Copyright 2020 ETH Zurich and University of Bologna.
-// Copyright and related rights are licensed under the Solderpad Hardware
-// License, Version 0.51 (the "License"); you may not use this file except in
-// compliance with the License. You may obtain a copy of the License at
-// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
-// or agreed to in writing, software, hardware and materials distributed under
-// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the
-// specific language governing permissions and limitations under the License.
+// Copyright 2023 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
 
 // Authors:
 // - Michael Rogenmoser <michaero@iis.ee.ethz.ch>
@@ -18,105 +12,105 @@
 /// utilization of 50%.
 module axi_to_detailed_mem_user #(
   /// AXI4+ATOP request type. See `include/axi/typedef.svh`.
-  parameter type         axi_req_t  = logic,
+  parameter  type         axi_req_t      = logic,
   /// AXI4+ATOP response type. See `include/axi/typedef.svh`.
-  parameter type         axi_resp_t = logic,
+  parameter  type         axi_resp_t     = logic,
   /// Address width, has to be less or equal than the width off the AXI address field.
   /// Determines the width of `mem_addr_o`. Has to be wide enough to emit the memory region
   /// which should be accessible.
-  parameter int unsigned AddrWidth  = 0,
+  parameter  int unsigned AddrWidth      = 0,
   /// AXI4+ATOP data width.
-  parameter int unsigned DataWidth  = 0,
+  parameter  int unsigned DataWidth      = 0,
   /// AXI4+ATOP ID width.
-  parameter int unsigned IdWidth    = 0,
+  parameter  int unsigned IdWidth        = 0,
   /// AXI4+ATOP user width.
-  parameter int unsigned UserWidth  = 0,
+  parameter  int unsigned UserWidth      = 0,
   /// Number of banks at output, must evenly divide `DataWidth`.
-  parameter int unsigned NumBanks   = 0,
+  parameter  int unsigned NumBanks       = 0,
   /// Depth of memory response buffer. This should be equal to the memory response latency.
-  parameter int unsigned BufDepth   = 1,
+  parameter  int unsigned BufDepth       = 1,
   /// Hide write requests if the strb == '0
-  parameter bit          HideStrb   = 1'b0,
+  parameter  bit          HideStrb       = 1'b0,
   /// Depth of output fifo/fall_through_register. Increase for asymmetric backpressure (contention) on banks.
-  parameter int unsigned OutFifoDepth = 1,
+  parameter  int unsigned OutFifoDepth   = 1,
   /// Prepend W user to `mem_user_o`.
-  parameter bit          PropagateWUser = 1'b0,
+  parameter  bit          PropagateWUser = 1'b0,
   /// Additional Signals for ruser calculation Width.
-  parameter int unsigned RUserExtra = 1,
+  parameter  int unsigned RUserExtra     = 1,
   /// Dependent parameter, do not override. Memory address type.
-  localparam type addr_t     = logic [AddrWidth-1:0],
+  localparam type         addr_t         = logic [                                 AddrWidth-1:0],
   /// Dependent parameter, do not override. Memory data type.
-  localparam type mem_data_t = logic [DataWidth/NumBanks-1:0],
+  localparam type         mem_data_t     = logic [                        DataWidth/NumBanks-1:0],
   /// Dependent parameter, do not override. Memory write strobe type.
-  localparam type mem_strb_t = logic [DataWidth/NumBanks/8-1:0],
+  localparam type         mem_strb_t     = logic [                      DataWidth/NumBanks/8-1:0],
   /// Dependent parameter, do not override. Memory id type.
-  localparam type mem_id_t   = logic [IdWidth-1:0],
+  localparam type         mem_id_t       = logic [                                   IdWidth-1:0],
   /// Dependent parameter, do not override. Memory user type.
-  localparam type mem_user_t = logic [UserWidth+(PropagateWUser ? UserWidth : 0)-1:0]
+  localparam type         mem_user_t     = logic [UserWidth+(PropagateWUser ? UserWidth : 0)-1:0]
 ) (
   /// Clock input.
-  input  logic                             clk_i,
+  input  logic                                             clk_i,
   /// Asynchronous reset, active low.
-  input  logic                             rst_ni,
+  input  logic                                             rst_ni,
   /// The unit is busy handling an AXI4+ATOP request.
-  output logic                             busy_o,
+  output logic                                             busy_o,
   /// AXI4+ATOP slave port, request input.
-  input  axi_req_t                         axi_req_i,
+  input  axi_req_t                                         axi_req_i,
   /// AXI4+ATOP slave port, response output.
-  output axi_resp_t                        axi_resp_o,
+  output axi_resp_t                                        axi_resp_o,
   /// Memory stream master, request is valid for this bank.
-  output logic             [NumBanks-1:0]  mem_req_o,
+  output logic             [ NumBanks-1:0]                 mem_req_o,
   /// Memory stream master, request can be granted by this bank.
-  input  logic             [NumBanks-1:0]  mem_gnt_i,
+  input  logic             [ NumBanks-1:0]                 mem_gnt_i,
   /// Memory stream master, byte address of the request.
-  output addr_t            [NumBanks-1:0]  mem_addr_o,
+  output addr_t            [ NumBanks-1:0]                 mem_addr_o,
   /// Memory stream master, write data for this bank. Valid when `mem_req_o`.
-  output mem_data_t        [NumBanks-1:0]  mem_wdata_o,
+  output mem_data_t        [ NumBanks-1:0]                 mem_wdata_o,
   /// Memory stream master, byte-wise strobe (byte enable).
-  output mem_strb_t        [NumBanks-1:0]  mem_strb_o,
+  output mem_strb_t        [ NumBanks-1:0]                 mem_strb_o,
   /// Memory stream master, `axi_pkg::atop_t` signal associated with this request.
-  output axi_pkg::atop_t   [NumBanks-1:0]  mem_atop_o,
+  output axi_pkg::atop_t   [ NumBanks-1:0]                 mem_atop_o,
   /// Memory stream master, lock signal.
-  output logic             [NumBanks-1:0]  mem_lock_o,
+  output logic             [ NumBanks-1:0]                 mem_lock_o,
   /// Memory stream master, write enable. Then asserted store of `mem_w_data` is requested.
-  output logic             [NumBanks-1:0]  mem_we_o,
+  output logic             [ NumBanks-1:0]                 mem_we_o,
   /// Memory stream master, ID. Response ID is managed internally, ensure in-order responses.
-  output mem_id_t          [NumBanks-1:0]  mem_id_o,
+  output mem_id_t          [ NumBanks-1:0]                 mem_id_o,
   /// Memory stream master, user signal. Ax channel user bits used.
-  output mem_user_t        [NumBanks-1:0]  mem_user_o,
+  output mem_user_t        [ NumBanks-1:0]                 mem_user_o,
   /// Memory stream master, cache signal.
-  output axi_pkg::cache_t  [NumBanks-1:0]  mem_cache_o,
+  output axi_pkg::cache_t  [ NumBanks-1:0]                 mem_cache_o,
   /// Memory stream master, protection signal.
-  output axi_pkg::prot_t   [NumBanks-1:0]  mem_prot_o,
+  output axi_pkg::prot_t   [ NumBanks-1:0]                 mem_prot_o,
   /// Memory stream master, QOS signal.
-  output axi_pkg::qos_t    [NumBanks-1:0]  mem_qos_o,
+  output axi_pkg::qos_t    [ NumBanks-1:0]                 mem_qos_o,
   /// Memory stream master, region signal.
-  output axi_pkg::region_t [NumBanks-1:0]  mem_region_o,
+  output axi_pkg::region_t [ NumBanks-1:0]                 mem_region_o,
   /// Memory stream master, response is valid. This module expects always a response valid for a
   /// request regardless if the request was a write or a read.
-  input  logic             [NumBanks-1:0]  mem_rvalid_i,
+  input  logic             [ NumBanks-1:0]                 mem_rvalid_i,
   /// Memory stream master, read response data.
-  input  mem_data_t        [NumBanks-1:0]  mem_rdata_i,
+  input  mem_data_t        [ NumBanks-1:0]                 mem_rdata_i,
   /// Memory stream master, error response.
-  input  logic             [NumBanks-1:0]  mem_err_i,
+  input  logic             [ NumBanks-1:0]                 mem_err_i,
   /// Memory stream master, read response exclusive access OK.
-  input  logic             [NumBanks-1:0]  mem_exokay_i,
+  input  logic             [ NumBanks-1:0]                 mem_exokay_i,
   /// Memory stream master, response custom signals for ruser calculation.
-  input  logic [NumBanks-1:0][RUserExtra-1:0]  mem_ruser_i,
+  input  logic             [ NumBanks-1:0][RUserExtra-1:0] mem_ruser_i,
   /// Signals for response user signal collection
-  output mem_user_t                           ruser_req_user_o,
-  output logic [NumBanks-1:0]                 ruser_req_bank_strb_o,
-  output logic [NumBanks-1:0]                 ruser_req_size_enable_o,
-  output logic [NumBanks-1:0][RUserExtra-1:0] ruser_rsp_extra_o,
-  output logic                                ruser_req_write_o,
-  output logic                                ruser_req_last_o,
-  output logic                                ruser_rsp_hs_o,
-  input  logic [UserWidth-1:0]                ruser_i
+  output mem_user_t                                        ruser_req_user_o,
+  output logic             [ NumBanks-1:0]                 ruser_req_bank_strb_o,
+  output logic             [ NumBanks-1:0]                 ruser_req_size_enable_o,
+  output logic             [ NumBanks-1:0][RUserExtra-1:0] ruser_rsp_extra_o,
+  output logic                                             ruser_req_write_o,
+  output logic                                             ruser_req_last_o,
+  output logic                                             ruser_rsp_hs_o,
+  input  logic             [UserWidth-1:0]                 ruser_i
 );
 
-  typedef logic [DataWidth-1:0]   axi_data_t;
+  typedef logic [DataWidth-1:0] axi_data_t;
   typedef logic [DataWidth/8-1:0] axi_strb_t;
-  typedef logic [IdWidth-1:0]     axi_id_t;
+  typedef logic [IdWidth-1:0] axi_id_t;
 
   typedef struct packed {
     addr_t            addr;
@@ -150,38 +144,46 @@ module axi_to_detailed_mem_user #(
   } meta_t;
 
   typedef struct packed {
-    axi_data_t           data;
-    logic [NumBanks-1:0] err;
-    logic [NumBanks-1:0] exokay;
+    axi_data_t                           data;
+    logic [NumBanks-1:0]                 err;
+    logic [NumBanks-1:0]                 exokay;
     logic [NumBanks-1:0][RUserExtra-1:0] ruser;
   } mem_rsp_t;
 
-  mem_rsp_t       mem_rdata,
-                  m2s_resp;
-  axi_pkg::len_t  r_cnt_d,        r_cnt_q,
-                  w_cnt_d,        w_cnt_q;
-  logic           arb_valid,      arb_ready,
-                  rd_valid,       rd_ready,
-                  wr_valid,       wr_ready,
-                  sel_b,          sel_buf_b,
-                  sel_r,          sel_buf_r,
-                  sel_valid,      sel_ready,
-                  sel_buf_valid,  sel_buf_ready,
-                  sel_lock_d,     sel_lock_q,
-                  meta_valid,     meta_ready,
-                  meta_buf_valid, meta_buf_ready,
-                  meta_sel_d,     meta_sel_q,
-                  m2s_req_valid,  m2s_req_ready,
-                  m2s_resp_valid, m2s_resp_ready,
-                  mem_req_valid,  mem_req_ready,
-                  mem_rvalid;
-  mem_req_t       m2s_req,
-                  mem_req;
-  meta_t          rd_meta,
-                  rd_meta_d,      rd_meta_q,
-                  wr_meta,
-                  wr_meta_d,      wr_meta_q,
-                  meta,           meta_buf;
+  mem_rsp_t mem_rdata, m2s_resp;
+  axi_pkg::len_t r_cnt_d, r_cnt_q, w_cnt_d, w_cnt_q;
+  logic
+      arb_valid,
+      arb_ready,
+      rd_valid,
+      rd_ready,
+      wr_valid,
+      wr_ready,
+      sel_b,
+      sel_buf_b,
+      sel_r,
+      sel_buf_r,
+      sel_valid,
+      sel_ready,
+      sel_buf_valid,
+      sel_buf_ready,
+      sel_lock_d,
+      sel_lock_q,
+      meta_valid,
+      meta_ready,
+      meta_buf_valid,
+      meta_buf_ready,
+      meta_sel_d,
+      meta_sel_q,
+      m2s_req_valid,
+      m2s_req_ready,
+      m2s_resp_valid,
+      m2s_resp_ready,
+      mem_req_valid,
+      mem_req_ready,
+      mem_rvalid;
+  mem_req_t m2s_req, mem_req;
+  meta_t rd_meta, rd_meta_d, rd_meta_q, wr_meta, wr_meta_d, wr_meta_q, meta, meta_buf;
 
   assign busy_o = axi_req_i.aw_valid | axi_req_i.ar_valid | axi_req_i.w_valid |
                     axi_resp_o.b_valid | axi_resp_o.r_valid |
@@ -205,26 +207,26 @@ module axi_to_detailed_mem_user #(
         r_cnt_d--;
         rd_meta_d.addr = rd_meta.addr;
       end
-    // Handle new AR if there is one.
+      // Handle new AR if there is one.
     end else if (axi_req_i.ar_valid) begin
       rd_meta_d = '{
-        addr:   addr_t'(axi_pkg::aligned_addr(axi_req_i.ar.addr, axi_req_i.ar.size)),
-        atop:   '0,
-        lock:   axi_req_i.ar.lock,
-        strb:   '0,
-        id:     axi_req_i.ar.id,
-        last:   (axi_req_i.ar.len == '0),
-        qos:    axi_req_i.ar.qos,
-        size:   axi_req_i.ar.size,
-        write:  1'b0,
-        user:   (PropagateWUser ? {{UserWidth{1'b0}}, axi_req_i.ar.user} : axi_req_i.ar.user),
-        cache:  axi_req_i.ar.cache,
-        prot:   axi_req_i.ar.prot,
-        region: axi_req_i.ar.region
+          addr: addr_t'(axi_pkg::aligned_addr(axi_req_i.ar.addr, axi_req_i.ar.size)),
+          atop: '0,
+          lock: axi_req_i.ar.lock,
+          strb: '0,
+          id: axi_req_i.ar.id,
+          last: (axi_req_i.ar.len == '0),
+          qos: axi_req_i.ar.qos,
+          size: axi_req_i.ar.size,
+          write: 1'b0,
+          user: (PropagateWUser ? {{UserWidth{1'b0}}, axi_req_i.ar.user} : axi_req_i.ar.user),
+          cache: axi_req_i.ar.cache,
+          prot: axi_req_i.ar.prot,
+          region: axi_req_i.ar.region
       };
-      rd_meta      = rd_meta_d;
+      rd_meta = rd_meta_d;
       rd_meta.addr = addr_t'(axi_req_i.ar.addr);
-      rd_valid     = 1'b1;
+      rd_valid = 1'b1;
       if (rd_ready) begin
         r_cnt_d             = axi_req_i.ar.len;
         axi_resp_o.ar_ready = 1'b1;
@@ -247,7 +249,7 @@ module axi_to_detailed_mem_user #(
       wr_meta        = wr_meta_d;
       wr_meta.addr   = wr_meta_q.addr + axi_pkg::num_bytes(wr_meta_q.size);
       if (axi_req_i.w_valid) begin
-        wr_valid = 1'b1;
+        wr_valid     = 1'b1;
         wr_meta.strb = axi_req_i.w.strb;
         if (PropagateWUser) begin
           wr_meta.user = {axi_req_i.w.user, wr_meta.user[UserWidth-1:0]};
@@ -258,46 +260,46 @@ module axi_to_detailed_mem_user #(
           wr_meta_d.addr = wr_meta.addr;
         end
       end
-    // Handle new AW if there is one.
+      // Handle new AW if there is one.
     end else if (axi_req_i.aw_valid && axi_req_i.w_valid) begin
       wr_meta_d = '{
-        addr:   addr_t'(axi_pkg::aligned_addr(axi_req_i.aw.addr, axi_req_i.aw.size)),
-        atop:   axi_req_i.aw.atop,
-        lock:   axi_req_i.aw.lock,
-        strb:   axi_req_i.w.strb,
-        id:     axi_req_i.aw.id,
-        last:   (axi_req_i.aw.len == '0),
-        qos:    axi_req_i.aw.qos,
-        size:   axi_req_i.aw.size,
-        write:  1'b1,
-        user:   PropagateWUser ? {axi_req_i.w.user, axi_req_i.aw.user} : axi_req_i.aw.user,
-        cache:  axi_req_i.aw.cache,
-        prot:   axi_req_i.aw.prot,
-        region: axi_req_i.aw.region
+          addr: addr_t'(axi_pkg::aligned_addr(axi_req_i.aw.addr, axi_req_i.aw.size)),
+          atop: axi_req_i.aw.atop,
+          lock: axi_req_i.aw.lock,
+          strb: axi_req_i.w.strb,
+          id: axi_req_i.aw.id,
+          last: (axi_req_i.aw.len == '0),
+          qos: axi_req_i.aw.qos,
+          size: axi_req_i.aw.size,
+          write: 1'b1,
+          user: PropagateWUser ? {axi_req_i.w.user, axi_req_i.aw.user} : axi_req_i.aw.user,
+          cache: axi_req_i.aw.cache,
+          prot: axi_req_i.aw.prot,
+          region: axi_req_i.aw.region
       };
       wr_meta = wr_meta_d;
       wr_meta.addr = addr_t'(axi_req_i.aw.addr);
       wr_valid = 1'b1;
       if (wr_ready) begin
-        w_cnt_d = axi_req_i.aw.len;
+        w_cnt_d             = axi_req_i.aw.len;
         axi_resp_o.aw_ready = 1'b1;
-        axi_resp_o.w_ready = 1'b1;
+        axi_resp_o.w_ready  = 1'b1;
       end
     end
   end
 
   // Arbitrate between reads and writes.
   stream_mux #(
-    .DATA_T ( meta_t ),
-    .N_INP  ( 32'd2  )
+    .DATA_T(meta_t),
+    .N_INP (32'd2)
   ) i_ax_mux (
-    .inp_data_i   ({wr_meta,  rd_meta }),
-    .inp_valid_i  ({wr_valid, rd_valid}),
-    .inp_ready_o  ({wr_ready, rd_ready}),
-    .inp_sel_i    ( meta_sel_d         ),
-    .oup_data_o   ( meta               ),
-    .oup_valid_o  ( arb_valid          ),
-    .oup_ready_i  ( arb_ready          )
+    .inp_data_i ({wr_meta, rd_meta}),
+    .inp_valid_i({wr_valid, rd_valid}),
+    .inp_ready_o({wr_ready, rd_ready}),
+    .inp_sel_i  (meta_sel_d),
+    .oup_data_o (meta),
+    .oup_valid_o(arb_valid),
+    .oup_ready_i(arb_ready)
   );
   always_comb begin
     meta_sel_d = meta_sel_q;
@@ -318,19 +320,19 @@ module axi_to_detailed_mem_user #(
           meta_sel_d = 1'b1;
         end else if (rd_meta.qos > wr_meta.qos) begin
           meta_sel_d = 1'b0;
-        // Decide requests with identical QoS.
+          // Decide requests with identical QoS.
         end else if (wr_meta.qos == rd_meta.qos) begin
           // 1. Prioritize individual writes over read bursts.
           // Rationale: Read bursts can be interleaved on AXI but write bursts cannot.
           if (wr_meta.last && !rd_meta.last) begin
             meta_sel_d = 1'b1;
-          // 2. Prioritize ongoing burst.
-          // Rationale: Stalled bursts create back-pressure or require costly buffers.
+            // 2. Prioritize ongoing burst.
+            // Rationale: Stalled bursts create back-pressure or require costly buffers.
           end else if (w_cnt_q > '0) begin
             meta_sel_d = 1'b1;
           end else if (r_cnt_q > '0) begin
             meta_sel_d = 1'b0;
-          // 3. Otherwise arbitrate round robin to prevent starvation.
+            // 3. Otherwise arbitrate round robin to prevent starvation.
           end else begin
             meta_sel_d = ~meta_sel_q;
           end
@@ -345,90 +347,90 @@ module axi_to_detailed_mem_user #(
 
   // Fork arbitrated stream to meta data, memory requests, and R/B channel selection.
   stream_fork #(
-    .N_OUP ( 32'd3 )
+    .N_OUP(32'd3)
   ) i_fork (
     .clk_i,
     .rst_ni,
-    .valid_i ( arb_valid                            ),
-    .ready_o ( arb_ready                            ),
-    .valid_o ({sel_valid, meta_valid, m2s_req_valid}),
-    .ready_i ({sel_ready, meta_ready, m2s_req_ready})
+    .valid_i(arb_valid),
+    .ready_o(arb_ready),
+    .valid_o({sel_valid, meta_valid, m2s_req_valid}),
+    .ready_i({sel_ready, meta_ready, m2s_req_ready})
   );
 
   assign sel_b = meta.write & meta.last;
   assign sel_r = ~meta.write | meta.atop[5];
 
   stream_fifo #(
-    .FALL_THROUGH ( 1'b1             ),
-    .DEPTH        ( 32'd1 + BufDepth ),
-    .T            ( logic[1:0]       )
+    .FALL_THROUGH(1'b1),
+    .DEPTH       (32'd1 + BufDepth),
+    .T           (logic [1:0])
   ) i_sel_buf (
     .clk_i,
     .rst_ni,
-    .flush_i    ( 1'b0                    ),
-    .testmode_i ( 1'b0                    ),
-    .data_i     ({sel_b,        sel_r    }),
-    .valid_i    ( sel_valid               ),
-    .ready_o    ( sel_ready               ),
-    .data_o     ({sel_buf_b,    sel_buf_r}),
-    .valid_o    ( sel_buf_valid           ),
-    .ready_i    ( sel_buf_ready           ),
-    .usage_o    ( /* unused */            )
+    .flush_i   (1'b0),
+    .testmode_i(1'b0),
+    .data_i    ({sel_b, sel_r}),
+    .valid_i   (sel_valid),
+    .ready_o   (sel_ready),
+    .data_o    ({sel_buf_b, sel_buf_r}),
+    .valid_o   (sel_buf_valid),
+    .ready_i   (sel_buf_ready),
+    .usage_o   (  /* unused */)
   );
 
   stream_fifo #(
-    .FALL_THROUGH ( 1'b1             ),
-    .DEPTH        ( 32'd1 + BufDepth ),
-    .T            ( meta_t           )
+    .FALL_THROUGH(1'b1),
+    .DEPTH       (32'd1 + BufDepth),
+    .T           (meta_t)
   ) i_meta_buf (
     .clk_i,
     .rst_ni,
-    .flush_i    ( 1'b0           ),
-    .testmode_i ( 1'b0           ),
-    .data_i     ( meta           ),
-    .valid_i    ( meta_valid     ),
-    .ready_o    ( meta_ready     ),
-    .data_o     ( meta_buf       ),
-    .valid_o    ( meta_buf_valid ),
-    .ready_i    ( meta_buf_ready ),
-    .usage_o    ( /* unused */   )
+    .flush_i   (1'b0),
+    .testmode_i(1'b0),
+    .data_i    (meta),
+    .valid_i   (meta_valid),
+    .ready_o   (meta_ready),
+    .data_o    (meta_buf),
+    .valid_o   (meta_buf_valid),
+    .ready_i   (meta_buf_ready),
+    .usage_o   (  /* unused */)
   );
 
   // Assemble the actual memory request from meta information and write data.
   assign m2s_req = mem_req_t'{
-    addr:   meta.addr,
-    atop:   meta.atop,
-    lock:   meta.lock,
-    strb:   axi_req_i.w.strb,
-    wdata:  axi_req_i.w.data,
-    we:     meta.write,
-    id:     meta.id,
-    user:   meta.user,
-    cache:  meta.cache,
-    prot:   meta.prot,
-    qos:    meta.qos,
-    region: meta.region
-  };
+          addr: meta.addr,
+          atop: meta.atop,
+          lock: meta.lock,
+          strb: axi_req_i.w.strb,
+          wdata: axi_req_i.w.data,
+          we: meta.write,
+          id: meta.id,
+          user: meta.user,
+          cache: meta.cache,
+          prot: meta.prot,
+          qos: meta.qos,
+          region: meta.region
+      };
 
   // Interface memory as stream.
   stream_to_mem #(
-    .mem_req_t  ( mem_req_t  ),
-    .mem_resp_t ( mem_rsp_t  ),
-    .BufDepth   ( BufDepth   )
+    .mem_req_t (mem_req_t),
+    .mem_resp_t(mem_rsp_t),
+    .BufDepth  (BufDepth)
   ) i_stream_to_mem (
     .clk_i,
     .rst_ni,
-    .req_i            ( m2s_req        ),
-    .req_valid_i      ( m2s_req_valid  ),
-    .req_ready_o      ( m2s_req_ready  ),
-    .resp_o           ( m2s_resp       ),
-    .resp_valid_o     ( m2s_resp_valid ),
-    .resp_ready_i     ( m2s_resp_ready ),
-    .mem_req_o        ( mem_req        ),
-    .mem_req_valid_o  ( mem_req_valid  ),
-    .mem_req_ready_i  ( mem_req_ready  ),
-    .mem_resp_i       ( mem_rdata      ),
-    .mem_resp_valid_i ( mem_rvalid     )
+    .req_i           (m2s_req),
+    .req_valid_i     (m2s_req_valid),
+    .req_ready_o     (m2s_req_ready),
+    .resp_o          (m2s_resp),
+    .resp_valid_o    (m2s_resp_valid),
+    .resp_ready_i    (m2s_resp_ready),
+    .mem_req_o       (mem_req),
+    .mem_req_valid_o (mem_req_valid),
+    .mem_req_ready_i (mem_req_ready),
+    .mem_resp_i      (mem_rdata),
+    .mem_resp_valid_i(mem_rvalid)
   );
 
   typedef struct packed {
@@ -442,103 +444,103 @@ module axi_to_detailed_mem_user #(
     axi_pkg::region_t region;
   } tmp_atop_t;
 
-  tmp_atop_t mem_req_atop;
+  tmp_atop_t                mem_req_atop;
   tmp_atop_t [NumBanks-1:0] banked_req_atop;
 
   assign mem_req_atop = '{
-    atop:   mem_req.atop,
-    lock:   mem_req.lock,
-    id:     mem_req.id,
-    user:   mem_req.user,
-    cache:  mem_req.cache,
-    prot:   mem_req.prot,
-    qos:    mem_req.qos,
-    region: mem_req.region
-  };
+          atop: mem_req.atop,
+          lock: mem_req.lock,
+          id: mem_req.id,
+          user: mem_req.user,
+          cache: mem_req.cache,
+          prot: mem_req.prot,
+          qos: mem_req.qos,
+          region: mem_req.region
+      };
 
   for (genvar i = 0; i < NumBanks; i++) begin : gen_atop_assign
-    assign mem_atop_o  [i] = banked_req_atop[i].atop;
-    assign mem_lock_o  [i] = banked_req_atop[i].lock;
-    assign mem_id_o    [i] = banked_req_atop[i].id;
-    assign mem_user_o  [i] = banked_req_atop[i].user;
-    assign mem_cache_o [i] = banked_req_atop[i].cache;
-    assign mem_prot_o  [i] = banked_req_atop[i].prot;
-    assign mem_qos_o   [i] = banked_req_atop[i].qos;
+    assign mem_atop_o[i]   = banked_req_atop[i].atop;
+    assign mem_lock_o[i]   = banked_req_atop[i].lock;
+    assign mem_id_o[i]     = banked_req_atop[i].id;
+    assign mem_user_o[i]   = banked_req_atop[i].user;
+    assign mem_cache_o[i]  = banked_req_atop[i].cache;
+    assign mem_prot_o[i]   = banked_req_atop[i].prot;
+    assign mem_qos_o[i]    = banked_req_atop[i].qos;
     assign mem_region_o[i] = banked_req_atop[i].region;
   end
 
   logic [NumBanks-1:0][RUserExtra+2-1:0] tmp_ersp, bank_ersp;
   for (genvar i = 0; i < NumBanks; i++) begin : gen_err_assign
-    assign mem_rdata.err[i]    = tmp_ersp[i][0];
-    assign mem_rdata.exokay[i] = tmp_ersp[i][1];
-    assign mem_rdata.ruser[i]  = tmp_ersp[i][RUserExtra+2-1:2];
-    assign bank_ersp[i][0] = mem_err_i[i];
-    assign bank_ersp[i][1] = mem_exokay_i[i];
+    assign mem_rdata.err[i]               = tmp_ersp[i][0];
+    assign mem_rdata.exokay[i]            = tmp_ersp[i][1];
+    assign mem_rdata.ruser[i]             = tmp_ersp[i][RUserExtra+2-1:2];
+    assign bank_ersp[i][0]                = mem_err_i[i];
+    assign bank_ersp[i][1]                = mem_exokay_i[i];
     assign bank_ersp[i][RUserExtra+2-1:2] = mem_ruser_i[i];
   end
 
   // Split single memory request to desired number of banks.
   mem_to_banks_detailed #(
-    .AddrWidth  ( AddrWidth         ),
-    .DataWidth  ( DataWidth         ),
-    .RUserWidth ( RUserExtra+2      ),
-    .NumBanks   ( NumBanks          ),
-    .HideStrb   ( HideStrb          ),
-    .MaxTrans   ( BufDepth          ),
-    .FifoDepth  ( OutFifoDepth      ),
-    .WUserWidth ( $bits(tmp_atop_t) )
+    .AddrWidth (AddrWidth),
+    .DataWidth (DataWidth),
+    .RUserWidth(RUserExtra + 2),
+    .NumBanks  (NumBanks),
+    .HideStrb  (HideStrb),
+    .MaxTrans  (BufDepth),
+    .FifoDepth (OutFifoDepth),
+    .WUserWidth($bits(tmp_atop_t))
   ) i_mem_to_banks (
     .clk_i,
     .rst_ni,
-    .req_i         ( mem_req_valid ),
-    .gnt_o         ( mem_req_ready ),
-    .addr_i        ( mem_req.addr  ),
-    .wdata_i       ( mem_req.wdata ),
-    .strb_i        ( mem_req.strb  ),
-    .wuser_i       ( mem_req_atop  ),
-    .we_i          ( mem_req.we    ),
-    .rvalid_o      ( mem_rvalid    ),
-    .rdata_o       ( mem_rdata.data ),
-    .ruser_o       ( tmp_ersp      ),
-    .bank_req_o    ( mem_req_o     ),
-    .bank_gnt_i    ( mem_gnt_i     ),
-    .bank_addr_o   ( mem_addr_o    ),
-    .bank_wdata_o  ( mem_wdata_o   ),
-    .bank_strb_o   ( mem_strb_o    ),
-    .bank_wuser_o  ( banked_req_atop ),
-    .bank_we_o     ( mem_we_o      ),
-    .bank_rvalid_i ( mem_rvalid_i  ),
-    .bank_rdata_i  ( mem_rdata_i   ),
-    .bank_ruser_i  ( bank_ersp     )
+    .req_i        (mem_req_valid),
+    .gnt_o        (mem_req_ready),
+    .addr_i       (mem_req.addr),
+    .wdata_i      (mem_req.wdata),
+    .strb_i       (mem_req.strb),
+    .wuser_i      (mem_req_atop),
+    .we_i         (mem_req.we),
+    .rvalid_o     (mem_rvalid),
+    .rdata_o      (mem_rdata.data),
+    .ruser_o      (tmp_ersp),
+    .bank_req_o   (mem_req_o),
+    .bank_gnt_i   (mem_gnt_i),
+    .bank_addr_o  (mem_addr_o),
+    .bank_wdata_o (mem_wdata_o),
+    .bank_strb_o  (mem_strb_o),
+    .bank_wuser_o (banked_req_atop),
+    .bank_we_o    (mem_we_o),
+    .bank_rvalid_i(mem_rvalid_i),
+    .bank_rdata_i (mem_rdata_i),
+    .bank_ruser_i (bank_ersp)
   );
 
   // Join memory read data and meta data stream.
   logic mem_join_valid, mem_join_ready;
   stream_join #(
-    .N_INP ( 32'd2 )
+    .N_INP(32'd2)
   ) i_join (
-    .inp_valid_i  ({m2s_resp_valid, meta_buf_valid}),
-    .inp_ready_o  ({m2s_resp_ready, meta_buf_ready}),
-    .oup_valid_o  ( mem_join_valid                 ),
-    .oup_ready_i  ( mem_join_ready                 )
+    .inp_valid_i({m2s_resp_valid, meta_buf_valid}),
+    .inp_ready_o({m2s_resp_ready, meta_buf_ready}),
+    .oup_valid_o(mem_join_valid),
+    .oup_ready_i(mem_join_ready)
   );
 
   // Dynamically fork the joined stream to B and R channels.
   stream_fork_dynamic #(
-    .N_OUP ( 32'd2 )
+    .N_OUP(32'd2)
   ) i_fork_dynamic (
     .clk_i,
     .rst_ni,
-    .valid_i      ( mem_join_valid                         ),
-    .ready_o      ( mem_join_ready                         ),
-    .sel_i        ({sel_buf_b,          sel_buf_r         }),
-    .sel_valid_i  ( sel_buf_valid                          ),
-    .sel_ready_o  ( sel_buf_ready                          ),
-    .valid_o      ({axi_resp_o.b_valid, axi_resp_o.r_valid}),
-    .ready_i      ({axi_req_i.b_ready,  axi_req_i.r_ready })
+    .valid_i    (mem_join_valid),
+    .ready_o    (mem_join_ready),
+    .sel_i      ({sel_buf_b, sel_buf_r}),
+    .sel_valid_i(sel_buf_valid),
+    .sel_ready_o(sel_buf_ready),
+    .valid_o    ({axi_resp_o.b_valid, axi_resp_o.r_valid}),
+    .ready_i    ({axi_req_i.b_ready, axi_req_i.r_ready})
   );
 
-  localparam int unsigned NumBytesPerBank = DataWidth/NumBanks/8;
+  localparam int unsigned NumBytesPerBank = DataWidth / NumBanks / 8;
 
   logic [NumBanks-1:0] meta_buf_bank_strb, meta_buf_size_enable;
   logic resp_b_err, resp_b_exokay, resp_r_err, resp_r_exokay;
@@ -547,7 +549,7 @@ module axi_to_detailed_mem_user #(
   // To ensure correct propagation, `err` is grouped with `OR` and `exokay` is grouped with `AND`.
   for (genvar i = 0; i < NumBanks; i++) begin : gen_meta_buf
     // Set active write banks based on strobe
-    assign meta_buf_bank_strb[i] = |meta_buf.strb[i*NumBytesPerBank +: NumBytesPerBank];
+    assign meta_buf_bank_strb[i] = |meta_buf.strb[i*NumBytesPerBank+:NumBytesPerBank];
     // Set active read banks based on size and address offset:
     //                 (bank.end > addr) && (bank.start < addr+size)
     assign meta_buf_size_enable[i] =
@@ -555,10 +557,10 @@ module axi_to_detailed_mem_user #(
            ((i*NumBytesPerBank) < ((meta_buf.addr % DataWidth/8) + 1<<meta_buf.size));
   end
   // Ensure only active banks are used
-  assign resp_b_err    = |(m2s_resp.err    &  meta_buf_bank_strb);   // strobe
-  assign resp_b_exokay = &(m2s_resp.exokay | ~meta_buf_bank_strb);   // strobe
-  assign resp_r_err    = |(m2s_resp.err    &  meta_buf_size_enable); // size & addr offset
-  assign resp_r_exokay = &(m2s_resp.exokay | ~meta_buf_size_enable); // size & addr offset
+  assign resp_b_err    = |(m2s_resp.err & meta_buf_bank_strb);  // strobe
+  assign resp_b_exokay = &(m2s_resp.exokay | ~meta_buf_bank_strb);  // strobe
+  assign resp_r_err    = |(m2s_resp.err & meta_buf_size_enable);  // size & addr offset
+  assign resp_r_exokay = &(m2s_resp.exokay | ~meta_buf_size_enable);  // size & addr offset
 
   logic collect_b_err_d, collect_b_err_q;
   logic collect_b_exokay_d, collect_b_exokay_q;
@@ -566,20 +568,20 @@ module axi_to_detailed_mem_user #(
 
   // Accumulate write errors for single B response
   // To ensure correct propagation, `err` is grouped with `OR` and `exokay` is grouped with `AND`.
-  assign next_collect_b_err = collect_b_err_q | resp_b_err;
+  assign next_collect_b_err    = collect_b_err_q | resp_b_err;
   assign next_collect_b_exokay = collect_b_exokay_q & resp_b_exokay;
 
   always_comb begin
     // By default we keep the previous value
-    collect_b_err_d = collect_b_err_q;
+    collect_b_err_d    = collect_b_err_q;
     collect_b_exokay_d = collect_b_exokay_q;
     // If the buffer is properly popped
     if (sel_buf_valid && sel_buf_ready) begin
       if (meta_buf.write && meta_buf.last) begin
-        collect_b_err_d = 1'b0;
+        collect_b_err_d    = 1'b0;
         collect_b_exokay_d = 1'b1;
       end else if (meta_buf.write) begin
-        collect_b_err_d = next_collect_b_err;
+        collect_b_err_d    = next_collect_b_err;
         collect_b_exokay_d = next_collect_b_exokay;
       end
     end
@@ -587,31 +589,45 @@ module axi_to_detailed_mem_user #(
 
   // Compose B responses.
   assign axi_resp_o.b = '{
-    id:   meta_buf.id,
-    resp: next_collect_b_err ?
-          axi_pkg::RESP_SLVERR :
-          next_collect_b_exokay ? axi_pkg::RESP_EXOKAY : axi_pkg::RESP_OKAY,
-    user: ruser_i
-  };
+          id: meta_buf.id,
+          resp:
+          next_collect_b_err
+          ?
+          axi_pkg::RESP_SLVERR
+          :
+          next_collect_b_exokay
+          ?
+          axi_pkg::RESP_EXOKAY
+          :
+          axi_pkg::RESP_OKAY,
+          user: ruser_i
+      };
 
   // Compose R responses.
   assign axi_resp_o.r = '{
-    data: m2s_resp.data,
-    id:   meta_buf.id,
-    last: meta_buf.last,
-    resp: resp_r_err ?
-          axi_pkg::RESP_SLVERR :
-          resp_r_exokay ? axi_pkg::RESP_EXOKAY : axi_pkg::RESP_OKAY,
-    user: ruser_i
-  };
+          data: m2s_resp.data,
+          id: meta_buf.id,
+          last: meta_buf.last,
+          resp:
+          resp_r_err
+          ?
+          axi_pkg::RESP_SLVERR
+          :
+          resp_r_exokay
+          ?
+          axi_pkg::RESP_EXOKAY
+          :
+          axi_pkg::RESP_OKAY,
+          user: ruser_i
+      };
 
-  assign ruser_req_user_o        = meta_buf.user;
-  assign ruser_req_bank_strb_o   = meta_buf_bank_strb;
+  assign ruser_req_user_o = meta_buf.user;
+  assign ruser_req_bank_strb_o = meta_buf_bank_strb;
   assign ruser_req_size_enable_o = meta_buf_size_enable;
-  assign ruser_req_write_o       = meta_buf.write;
-  assign ruser_req_last_o        = meta_buf.last;
-  assign ruser_rsp_hs_o          = sel_buf_valid && sel_buf_ready;
-  assign ruser_rsp_extra_o       = m2s_resp.ruser;
+  assign ruser_req_write_o = meta_buf.write;
+  assign ruser_req_last_o = meta_buf.last;
+  assign ruser_rsp_hs_o = sel_buf_valid && sel_buf_ready;
+  assign ruser_rsp_extra_o = m2s_resp.ruser;
 
   // Registers
   `FFARN(meta_sel_q, meta_sel_d, 1'b0, clk_i, rst_ni)
@@ -625,31 +641,36 @@ module axi_to_detailed_mem_user #(
 
   // Assertions
   // pragma translate_off
-  `ifndef VERILATOR
+`ifndef VERILATOR
   default disable iff (!rst_ni);
-  assume property (@(posedge clk_i)
-      axi_req_i.ar_valid && !axi_resp_o.ar_ready |=> $stable(axi_req_i.ar))
-    else $error("AR must remain stable until handshake has happened!");
-  assert property (@(posedge clk_i)
-      axi_resp_o.r_valid && !axi_req_i.r_ready |=> $stable(axi_resp_o.r))
-    else $error("R must remain stable until handshake has happened!");
-  assume property (@(posedge clk_i)
-      axi_req_i.aw_valid && !axi_resp_o.aw_ready |=> $stable(axi_req_i.aw))
-    else $error("AW must remain stable until handshake has happened!");
-  assume property (@(posedge clk_i)
-      axi_req_i.w_valid && !axi_resp_o.w_ready |=> $stable(axi_req_i.w))
-    else $error("W must remain stable until handshake has happened!");
-  assert property (@(posedge clk_i)
-      axi_resp_o.b_valid && !axi_req_i.b_ready |=> $stable(axi_resp_o.b))
-    else $error("B must remain stable until handshake has happened!");
+  assume property (@(posedge clk_i) axi_req_i.ar_valid && !axi_resp_o.ar_ready |=> $stable(
+      axi_req_i.ar
+  ))
+  else $error("AR must remain stable until handshake has happened!");
+  assert property (@(posedge clk_i) axi_resp_o.r_valid && !axi_req_i.r_ready |=> $stable(
+      axi_resp_o.r
+  ))
+  else $error("R must remain stable until handshake has happened!");
+  assume property (@(posedge clk_i) axi_req_i.aw_valid && !axi_resp_o.aw_ready |=> $stable(
+      axi_req_i.aw
+  ))
+  else $error("AW must remain stable until handshake has happened!");
+  assume property (@(posedge clk_i) axi_req_i.w_valid && !axi_resp_o.w_ready |=> $stable(
+      axi_req_i.w
+  ))
+  else $error("W must remain stable until handshake has happened!");
+  assert property (@(posedge clk_i) axi_resp_o.b_valid && !axi_req_i.b_ready |=> $stable(
+      axi_resp_o.b
+  ))
+  else $error("B must remain stable until handshake has happened!");
   assert property (@(posedge clk_i) axi_req_i.ar_valid && axi_req_i.ar.len > 0 |->
       axi_req_i.ar.burst == axi_pkg::BURST_INCR)
-    else $error("Non-incrementing bursts are not supported!");
+  else $error("Non-incrementing bursts are not supported!");
   assert property (@(posedge clk_i) axi_req_i.aw_valid && axi_req_i.aw.len > 0 |->
       axi_req_i.aw.burst == axi_pkg::BURST_INCR)
-    else $error("Non-incrementing bursts are not supported!");
+  else $error("Non-incrementing bursts are not supported!");
   assert property (@(posedge clk_i) meta_valid && meta.atop != '0 |-> meta.write)
-    else $warning("Unexpected atomic operation on read.");
-  `endif
+  else $warning("Unexpected atomic operation on read.");
+`endif
   // pragma translate_on
 endmodule

--- a/hw/axi_obi/src/axi_to_obi.sv
+++ b/hw/axi_obi/src/axi_to_obi.sv
@@ -1,0 +1,353 @@
+// Copyright 2023 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+// Michael Rogenmoser <michaero@iis.ee.ethz.ch>
+
+module axi_to_obi #(
+  /// The configuration of the OBI port (input port).
+  parameter obi_pkg::obi_cfg_t ObiCfg      = obi_pkg::ObiDefaultConfig,
+  /// The request struct of the OBI port
+  parameter type               obi_req_t = logic,
+  /// The response struct of the OBI port
+  parameter type               obi_rsp_t = logic,
+  /// The A struct of the OBI port
+  parameter type               obi_a_chan_t = logic,
+  /// The R struct of the OBI port
+  parameter type               obi_r_chan_t = logic,
+  /// AXI Address Width
+  parameter int unsigned       AxiAddrWidth = ObiCfg.AddrWidth,
+  /// AXI Data Width
+  parameter int unsigned       AxiDataWidth = ObiCfg.DataWidth,
+  /// AXI ID Width
+  parameter int unsigned       AxiIdWidth   = 0,
+  /// AXI User Width
+  parameter int unsigned       AxiUserWidth = 0,
+
+  parameter int unsigned       MaxTrans = 0,
+  /// The request struct of the AXI port
+  parameter type               axi_req_t = logic,
+  /// The response struct of the AXI port
+  parameter type               axi_rsp_t = logic,
+  // Dependent Parameters, *DO NOT OVERWRITE*
+  parameter int unsigned       NumBanks = AxiDataWidth/ObiCfg.DataWidth,
+  parameter int unsigned       AUserWidthAdjusted = ObiCfg.OptionalCfg.AUserWidth ?
+                                                    ObiCfg.OptionalCfg.AUserWidth : 1,
+  parameter int unsigned       WUserWidthAdjusted = ObiCfg.OptionalCfg.WUserWidth ?
+                                                    ObiCfg.OptionalCfg.WUserWidth : 1,
+  parameter int unsigned       RUserWidthAdjusted = ObiCfg.OptionalCfg.RUserWidth ?
+                                                    ObiCfg.OptionalCfg.RUserWidth : 1
+) (
+  input  logic     clk_i,
+  input  logic     rst_ni,
+  input  logic     testmode_i,
+
+  input  axi_req_t axi_req_i,
+  output axi_rsp_t axi_rsp_o,
+
+  output obi_req_t obi_req_o,
+  input  obi_rsp_t obi_rsp_i,
+
+  // Combinatorial request user assignment signals. If not used, assign '0 to *_i.
+  output logic [NumBanks-1:0][        AxiIdWidth-1:0] req_aw_id_o,
+  output logic [NumBanks-1:0][      AxiUserWidth-1:0] req_aw_user_o,
+  output logic [NumBanks-1:0][      AxiUserWidth-1:0] req_w_user_o,
+  input  logic [NumBanks-1:0][    ObiCfg.IdWidth-1:0] req_write_aid_i,
+  input  logic [NumBanks-1:0][AUserWidthAdjusted-1:0] req_write_auser_i,
+  input  logic [NumBanks-1:0][WUserWidthAdjusted-1:0] req_write_wuser_i,
+
+  output logic [NumBanks-1:0][        AxiIdWidth-1:0] req_ar_id_o,
+  output logic [NumBanks-1:0][      AxiUserWidth-1:0] req_ar_user_o,
+  input  logic [NumBanks-1:0][    ObiCfg.IdWidth-1:0] req_read_aid_i,
+  input  logic [NumBanks-1:0][AUserWidthAdjusted-1:0] req_read_auser_i,
+
+  output logic               [      AxiUserWidth-1:0] rsp_write_aw_user_o,
+  output logic               [      AxiUserWidth-1:0] rsp_write_w_user_o,
+  output logic [NumBanks-1:0]                         rsp_write_bank_strb_o,
+  output logic [NumBanks-1:0][    ObiCfg.IdWidth-1:0] rsp_write_rid_o,
+  output logic [NumBanks-1:0][RUserWidthAdjusted-1:0] rsp_write_ruser_o,
+  output logic                                        rsp_write_last_o,
+  output logic                                        rsp_write_hs_o,
+  input  logic               [      AxiUserWidth-1:0] rsp_b_user_i,
+
+  output logic               [      AxiUserWidth-1:0] rsp_read_ar_user_o,
+  output logic [NumBanks-1:0]                         rsp_read_size_enable_o,
+  output logic [NumBanks-1:0][    ObiCfg.IdWidth-1:0] rsp_read_rid_o,
+  output logic [NumBanks-1:0][RUserWidthAdjusted-1:0] rsp_read_ruser_o,
+  input  logic               [      AxiUserWidth-1:0] rsp_r_user_i
+);
+  typedef struct packed {
+    logic [AxiIdWidth-1:0] atop_id;
+    logic                  lock;
+    logic [5:0]            atop;
+  } tmp_atop_t;
+
+  axi_req_t axi_read_req, axi_write_req;
+  axi_rsp_t axi_read_rsp, axi_write_rsp;
+
+  localparam int unsigned IdRuserWidth = ObiCfg.IdWidth+ObiCfg.OptionalCfg.RUserWidth;
+
+  logic            [2*NumBanks-1:0]                         bank_mem_req;
+  logic            [2*NumBanks-1:0]                         bank_mem_gnt;
+  logic            [2*NumBanks-1:0][      AxiAddrWidth-1:0] bank_mem_addr;
+  logic            [2*NumBanks-1:0][  ObiCfg.DataWidth-1:0] bank_mem_wdata;
+  logic            [2*NumBanks-1:0][ObiCfg.DataWidth/8-1:0] bank_mem_strb;
+  axi_pkg::atop_t  [2*NumBanks-1:0]                         bank_mem_atop;
+  logic            [2*NumBanks-1:0]                         bank_mem_lock;
+  logic            [2*NumBanks-1:0][        AxiIdWidth-1:0] bank_mem_id;
+  logic            [2*NumBanks-1:0][      AxiUserWidth-1:0] bank_mem_user;
+  logic            [2*NumBanks-1:0]                         bank_mem_we;
+  axi_pkg::cache_t [2*NumBanks-1:0]                         bank_mem_cache;
+  axi_pkg::prot_t  [2*NumBanks-1:0]                         bank_mem_prot;
+  logic            [2*NumBanks-1:0]                         bank_mem_rvalid;
+  logic            [2*NumBanks-1:0][  ObiCfg.DataWidth-1:0] bank_mem_rdata;
+  logic            [2*NumBanks-1:0]                         bank_mem_err;
+  logic            [2*NumBanks-1:0]                         bank_mem_exokay;
+  logic            [2*NumBanks-1:0][      IdRuserWidth-1:0] bank_mem_ruser;
+
+  logic [2*NumBanks-1:0][  IdRuserWidth-1:0] rsp_ruser;
+  logic [  NumBanks-1:0][2*AxiUserWidth-1:0] tmp_write_user;
+
+  obi_req_t [2*NumBanks-1:0] obi_reqs;
+  obi_rsp_t [2*NumBanks-1:0] obi_rsps;
+
+  obi_pkg::atop_t [2*NumBanks-1:0] obi_atop;
+
+  axi_demux_simple #(
+    .AxiIdWidth  ( AxiIdWidth ),
+    .AtopSupport ( 1'b1       ),
+    .axi_req_t   ( axi_req_t  ),
+    .axi_resp_t  ( axi_rsp_t  ),
+    .NoMstPorts  ( 2          ),
+    .MaxTrans    ( MaxTrans   ),
+    .AxiLookBits ( 1          ),
+    .UniqueIds   ( 1'b1       )
+  ) i_read_write_demux (
+    .clk_i,
+    .rst_ni,
+    .test_i         ( testmode_i ),
+    .slv_req_i      ( axi_req_i  ),
+    .slv_resp_o     ( axi_rsp_o  ),
+    .slv_ar_select_i( 1'b0       ),
+    .slv_aw_select_i( 1'b1       ),
+    .mst_reqs_o     ( {axi_write_req, axi_read_req} ),
+    .mst_resps_i    ( {axi_write_rsp, axi_read_rsp} )
+  );
+
+  axi_to_detailed_mem_user #(
+    .axi_req_t   ( axi_req_t ),
+    .axi_resp_t  ( axi_rsp_t ),
+    .AddrWidth   ( AxiAddrWidth ),
+    .DataWidth   ( AxiDataWidth ),
+    .IdWidth     ( AxiIdWidth   ),
+    .UserWidth   ( AxiUserWidth ),
+    .NumBanks    ( NumBanks     ),
+    .BufDepth    ( MaxTrans     ),
+    .HideStrb    ( 1'b1         ),
+    .OutFifoDepth( 2            ),
+    .PropagateWUser ( 1'b0      ),
+    .RUserExtra    (IdRuserWidth)
+  ) i_axi_to_mem_read (
+    .clk_i,
+    .rst_ni,
+
+    .busy_o      (),
+
+    .axi_req_i   ( axi_read_req ),
+    .axi_resp_o  ( axi_read_rsp ),
+
+    .mem_req_o   ( bank_mem_req   [NumBanks-1:0] ),
+    .mem_gnt_i   ( bank_mem_gnt   [NumBanks-1:0] ),
+    .mem_addr_o  ( bank_mem_addr  [NumBanks-1:0] ),
+    .mem_wdata_o ( bank_mem_wdata [NumBanks-1:0] ),
+    .mem_strb_o  ( bank_mem_strb  [NumBanks-1:0] ),
+    .mem_atop_o  ( bank_mem_atop  [NumBanks-1:0] ),
+    .mem_lock_o  ( bank_mem_lock  [NumBanks-1:0] ),
+    .mem_we_o    (), // bank_mem_we    [NumBanks-1:0] ),
+    .mem_id_o    ( req_ar_id_o ), // bank_mem_id    [NumBanks-1:0] ),
+    .mem_user_o  ( req_ar_user_o ), // bank_mem_user  [NumBanks-1:0] ),
+    .mem_cache_o ( bank_mem_cache [NumBanks-1:0] ),
+    .mem_prot_o  ( bank_mem_prot  [NumBanks-1:0] ),
+    .mem_qos_o   (),
+    .mem_region_o(),
+    .mem_rvalid_i( bank_mem_rvalid[NumBanks-1:0] ),
+    .mem_rdata_i ( bank_mem_rdata [NumBanks-1:0] ),
+    .mem_err_i   ( bank_mem_err   [NumBanks-1:0] ),
+    .mem_exokay_i( bank_mem_exokay[NumBanks-1:0] ),
+    .mem_ruser_i ( bank_mem_ruser [NumBanks-1:0] ),
+
+    .ruser_req_user_o       ( rsp_read_ar_user_o ),
+    .ruser_req_bank_strb_o  (),
+    .ruser_req_size_enable_o( rsp_read_size_enable_o ),
+    .ruser_rsp_extra_o      ( rsp_ruser[NumBanks-1:0] ),
+    .ruser_req_write_o      (),
+    .ruser_req_last_o       (),
+    .ruser_rsp_hs_o         (),
+    .ruser_i                ( rsp_r_user_i )
+  );
+  assign bank_mem_we [NumBanks-1:0] = '0;
+  assign bank_mem_id [NumBanks-1:0] = req_read_aid_i;
+  assign bank_mem_user [NumBanks-1:0] = req_read_auser_i;
+
+  axi_to_detailed_mem_user #(
+    .axi_req_t   ( axi_req_t    ),
+    .axi_resp_t  ( axi_rsp_t    ),
+    .AddrWidth   ( AxiAddrWidth ),
+    .DataWidth   ( AxiDataWidth ),
+    .IdWidth     ( AxiIdWidth   ),
+    .UserWidth   ( AxiUserWidth ),
+    .NumBanks    ( NumBanks     ),
+    .BufDepth    ( MaxTrans     ),
+    .HideStrb    ( 1'b1         ),
+    .OutFifoDepth( 2            ),
+    .PropagateWUser(1'b1),
+    .RUserExtra    (IdRuserWidth)
+  ) i_axi_to_mem_write (
+    .clk_i,
+    .rst_ni,
+
+    .busy_o      (),
+
+    .axi_req_i   ( axi_write_req ),
+    .axi_resp_o  ( axi_write_rsp ),
+
+    .mem_req_o   ( bank_mem_req   [2*NumBanks-1:NumBanks] ),
+    .mem_gnt_i   ( bank_mem_gnt   [2*NumBanks-1:NumBanks] ),
+    .mem_addr_o  ( bank_mem_addr  [2*NumBanks-1:NumBanks] ),
+    .mem_wdata_o ( bank_mem_wdata [2*NumBanks-1:NumBanks] ),
+    .mem_strb_o  ( bank_mem_strb  [2*NumBanks-1:NumBanks] ),
+    .mem_atop_o  ( bank_mem_atop  [2*NumBanks-1:NumBanks] ),
+    .mem_lock_o  ( bank_mem_lock  [2*NumBanks-1:NumBanks] ),
+    .mem_we_o    (), // bank_mem_we    [2*NumBanks-1:NumBanks] ),
+    .mem_id_o    ( req_aw_id_o ), // bank_mem_id    [2*NumBanks-1:NumBanks] ),
+    .mem_user_o  ( tmp_write_user ), // bank_mem_user  [2*NumBanks-1:NumBanks] ),
+    .mem_cache_o ( bank_mem_cache [2*NumBanks-1:NumBanks] ),
+    .mem_prot_o  ( bank_mem_prot  [2*NumBanks-1:NumBanks] ),
+    .mem_qos_o   (),
+    .mem_region_o(),
+    .mem_rvalid_i( bank_mem_rvalid[2*NumBanks-1:NumBanks] ),
+    .mem_rdata_i ( bank_mem_rdata [2*NumBanks-1:NumBanks] ),
+    .mem_err_i   ( bank_mem_err   [2*NumBanks-1:NumBanks] ),
+    .mem_exokay_i( bank_mem_exokay[2*NumBanks-1:NumBanks] ),
+    .mem_ruser_i ( bank_mem_ruser [2*NumBanks-1:NumBanks] ),
+
+    .ruser_req_user_o       ( {rsp_write_w_user_o, rsp_write_aw_user_o} ),
+    .ruser_req_bank_strb_o  ( rsp_write_bank_strb_o ),
+    .ruser_req_size_enable_o(),
+    .ruser_rsp_extra_o      ( rsp_ruser[2*NumBanks-1:NumBanks] ),
+    .ruser_req_write_o      (),
+    .ruser_req_last_o       ( rsp_write_last_o ),
+    .ruser_rsp_hs_o         ( rsp_write_hs_o ),
+    .ruser_i                ( rsp_b_user_i )
+  );
+  assign bank_mem_we [2*NumBanks-1:NumBanks] = {NumBanks{1'b1}};
+  assign bank_mem_id    [2*NumBanks-1:NumBanks] = req_write_aid_i;
+  assign bank_mem_user  [2*NumBanks-1:NumBanks] = req_write_auser_i;
+
+  for (genvar i = 0; i < NumBanks; i++) begin : gen_user_rid
+    assign req_w_user_o[i] = tmp_write_user[i][2*AxiUserWidth-1:AxiUserWidth];
+    assign req_aw_user_o[i] = tmp_write_user[i][AxiUserWidth-1:0];
+    assign rsp_read_rid_o   [i] = rsp_ruser[         i][ObiCfg.IdWidth-1:0];
+    assign rsp_write_rid_o  [i] = rsp_ruser[NumBanks+i][ObiCfg.IdWidth-1:0];
+    if (ObiCfg.IdWidth > ObiCfg.IdWidth) begin : gen_user_resp
+    	assign rsp_read_ruser_o [i] = rsp_ruser[         i][IdRuserWidth-1:ObiCfg.IdWidth];
+    	assign rsp_write_ruser_o[i] = rsp_ruser[NumBanks+i][IdRuserWidth-1:ObiCfg.IdWidth];
+    end
+  end
+
+  if (ObiCfg.OptionalCfg.UseAtop) begin : gen_atop
+    for (genvar i = 0; i < 2*NumBanks; i++) begin : gen_atop_banks
+      always_comb begin : proc_atop_translate
+        obi_atop[i] = obi_pkg::ATOPNONE;
+        if (bank_mem_lock[i]) begin
+          obi_atop[i] = bank_mem_we[i] ? obi_pkg::ATOPSC : obi_pkg::ATOPLR;
+        end else if (bank_mem_atop[i] == axi_pkg::ATOP_ATOMICSWAP) begin
+          obi_atop[i] = obi_pkg::AMOSWAP;
+        end else if (bank_mem_atop[i] != '0) begin
+          case (bank_mem_atop[i][2:0])
+            axi_pkg::ATOP_ADD: obi_atop[i] = obi_pkg::AMOADD;
+            axi_pkg::ATOP_EOR: obi_atop[i] = obi_pkg::AMOXOR;
+            axi_pkg::ATOP_CLR: obi_atop[i] = obi_pkg::AMOAND;
+            axi_pkg::ATOP_SET: obi_atop[i] = obi_pkg::AMOOR;
+            axi_pkg::ATOP_SMIN: obi_atop[i] = obi_pkg::AMOMIN;
+            axi_pkg::ATOP_SMAX: obi_atop[i] = obi_pkg::AMOMAX;
+            axi_pkg::ATOP_UMIN: obi_atop[i] = obi_pkg::AMOMINU;
+            axi_pkg::ATOP_UMAX: obi_atop[i] = obi_pkg::AMOMAXU;
+            default: ;
+          endcase
+        end
+      end
+    end
+  end else begin : gen_tie_atop
+    assign obi_atop = '0;
+  end
+
+  for (genvar i = 0; i < 2*NumBanks; i++) begin : gen_obi_bank_assign
+    assign obi_reqs[i].req     = bank_mem_req[i];
+    assign bank_mem_gnt[i]     = obi_rsps[i].gnt;
+    assign obi_reqs[i].a.addr  = bank_mem_addr[i];
+    if (ObiCfg.OptionalCfg.UseAtop) begin : gen_obi_bank_assign_atop
+      assign obi_reqs[i].a.a_optional.atop = obi_atop[i];
+      assign obi_reqs[i].a.wdata = (obi_atop[i] == obi_pkg::AMOAND) ?
+                                   ~bank_mem_wdata[i] : bank_mem_wdata[i];
+      assign bank_mem_exokay[i] = obi_rsps[i].r.r_optional.exokay;
+    end else begin : gen_obi_bank_tie_atop
+      assign obi_reqs[i].a.wdata = bank_mem_wdata[i];
+      assign bank_mem_exokay[i] = '0;
+    end
+    assign obi_reqs[i].a.be    = bank_mem_strb[i];
+    assign obi_reqs[i].a.we    = bank_mem_we[i];
+    assign bank_mem_rvalid[i]  = obi_rsps[i].rvalid;
+    assign bank_mem_rdata[i]   = obi_rsps[i].r.rdata;
+    assign bank_mem_err[i]     = obi_rsps[i].r.err;
+    assign bank_mem_ruser[i][ObiCfg.IdWidth-1:0] = obi_rsps[i].r.rid;
+    if (ObiCfg.OptionalCfg.RUserWidth) begin : gen_ruser
+      assign bank_mem_ruser[i][IdRuserWidth-1:ObiCfg.IdWidth] = obi_rsps[i].r.r_optional.ruser;
+    end
+    if (ObiCfg.OptionalCfg.UseProt) begin : gen_obi_bank_assign_prot
+      assign obi_reqs[i].a.a_optional.prot[0] = ~bank_mem_prot[i][2];
+      assign obi_reqs[i].a.a_optional.prot[1] = ~bank_mem_prot[i][0];
+      assign obi_reqs[i].a.a_optional.prot[2] = ~bank_mem_prot[i][0];
+    end
+    if (ObiCfg.OptionalCfg.UseMemtype) begin : gen_obi_bank_assign_memtype
+      assign obi_reqs[i].a.a_optional.memtype[0] = bank_mem_cache[i][0];
+      assign obi_reqs[i].a.a_optional.memtype[1] = ~bank_mem_cache[i][1];
+    end
+    assign obi_reqs[i].a.aid = bank_mem_id[i];
+    if (i < NumBanks) begin : gen_bank_auser
+      if (ObiCfg.OptionalCfg.AUserWidth) begin : gen_auser
+        assign obi_reqs[i].a.a_optional.auser = req_read_auser_i;
+      end
+    end else begin : gen_bank_awuser
+      if (ObiCfg.OptionalCfg.AUserWidth) begin : gen_auser
+        assign obi_reqs[i].a.a_optional.auser = req_write_auser_i;
+      end
+      if (ObiCfg.OptionalCfg.WUserWidth) begin : gen_wuser
+        assign obi_reqs[i].a.a_optional.wuser = req_write_wuser_i;
+      end
+    end
+  end
+
+  obi_mux #(
+    .MgrPortObiCfg      ( ObiCfg       ),
+    .SbrPortObiCfg      ( ObiCfg       ),
+    .sbr_port_obi_req_t ( obi_req_t    ),
+    .sbr_port_obi_rsp_t ( obi_rsp_t    ),
+    .sbr_port_a_chan_t  ( obi_a_chan_t ),
+    .sbr_port_r_chan_t  ( obi_r_chan_t ),
+    .mgr_port_obi_req_t ( obi_req_t    ),
+    .mgr_port_obi_rsp_t ( obi_rsp_t    ),
+    .NumSbrPorts        ( 2*NumBanks   ),
+    .NumMaxTrans        ( MaxTrans     ),
+    .UseIdForRouting    ( 1'b0         )
+  ) i_mux_banks (
+    .clk_i,
+    .rst_ni,
+    .testmode_i,
+    .sbr_ports_req_i( obi_reqs  ),
+    .sbr_ports_rsp_o( obi_rsps  ),
+    .mgr_port_req_o ( obi_req_o ),
+    .mgr_port_rsp_i ( obi_rsp_i )
+  );
+
+endmodule

--- a/hw/axi_obi/src/axi_to_obi.sv
+++ b/hw/axi_obi/src/axi_to_obi.sv
@@ -6,11 +6,11 @@
 
 module axi_to_obi #(
   /// The configuration of the OBI port (input port).
-  parameter obi_pkg::obi_cfg_t ObiCfg      = obi_pkg::ObiDefaultConfig,
+  parameter obi_pkg::obi_cfg_t ObiCfg       = obi_pkg::ObiDefaultConfig,
   /// The request struct of the OBI port
-  parameter type               obi_req_t = logic,
+  parameter type               obi_req_t    = logic,
   /// The response struct of the OBI port
-  parameter type               obi_rsp_t = logic,
+  parameter type               obi_rsp_t    = logic,
   /// The A struct of the OBI port
   parameter type               obi_a_chan_t = logic,
   /// The R struct of the OBI port
@@ -24,13 +24,13 @@ module axi_to_obi #(
   /// AXI User Width
   parameter int unsigned       AxiUserWidth = 0,
 
-  parameter int unsigned       MaxTrans = 0,
+  parameter int unsigned MaxTrans = 0,
   /// The request struct of the AXI port
-  parameter type               axi_req_t = logic,
+  parameter type axi_req_t = logic,
   /// The response struct of the AXI port
-  parameter type               axi_rsp_t = logic,
+  parameter type axi_rsp_t = logic,
   // Dependent Parameters, *DO NOT OVERWRITE*
-  parameter int unsigned       NumBanks = AxiDataWidth/ObiCfg.DataWidth,
+  parameter int unsigned NumBanks = AxiDataWidth / ObiCfg.DataWidth,
   parameter int unsigned       AUserWidthAdjusted = ObiCfg.OptionalCfg.AUserWidth ?
                                                     ObiCfg.OptionalCfg.AUserWidth : 1,
   parameter int unsigned       WUserWidthAdjusted = ObiCfg.OptionalCfg.WUserWidth ?
@@ -38,9 +38,9 @@ module axi_to_obi #(
   parameter int unsigned       RUserWidthAdjusted = ObiCfg.OptionalCfg.RUserWidth ?
                                                     ObiCfg.OptionalCfg.RUserWidth : 1
 ) (
-  input  logic     clk_i,
-  input  logic     rst_ni,
-  input  logic     testmode_i,
+  input logic clk_i,
+  input logic rst_ni,
+  input logic testmode_i,
 
   input  axi_req_t axi_req_i,
   output axi_rsp_t axi_rsp_o,
@@ -61,20 +61,20 @@ module axi_to_obi #(
   input  logic [NumBanks-1:0][    ObiCfg.IdWidth-1:0] req_read_aid_i,
   input  logic [NumBanks-1:0][AUserWidthAdjusted-1:0] req_read_auser_i,
 
-  output logic               [      AxiUserWidth-1:0] rsp_write_aw_user_o,
-  output logic               [      AxiUserWidth-1:0] rsp_write_w_user_o,
-  output logic [NumBanks-1:0]                         rsp_write_bank_strb_o,
-  output logic [NumBanks-1:0][    ObiCfg.IdWidth-1:0] rsp_write_rid_o,
-  output logic [NumBanks-1:0][RUserWidthAdjusted-1:0] rsp_write_ruser_o,
-  output logic                                        rsp_write_last_o,
-  output logic                                        rsp_write_hs_o,
-  input  logic               [      AxiUserWidth-1:0] rsp_b_user_i,
+  output logic [AxiUserWidth-1:0]                         rsp_write_aw_user_o,
+  output logic [AxiUserWidth-1:0]                         rsp_write_w_user_o,
+  output logic [    NumBanks-1:0]                         rsp_write_bank_strb_o,
+  output logic [    NumBanks-1:0][    ObiCfg.IdWidth-1:0] rsp_write_rid_o,
+  output logic [    NumBanks-1:0][RUserWidthAdjusted-1:0] rsp_write_ruser_o,
+  output logic                                            rsp_write_last_o,
+  output logic                                            rsp_write_hs_o,
+  input  logic [AxiUserWidth-1:0]                         rsp_b_user_i,
 
-  output logic               [      AxiUserWidth-1:0] rsp_read_ar_user_o,
-  output logic [NumBanks-1:0]                         rsp_read_size_enable_o,
-  output logic [NumBanks-1:0][    ObiCfg.IdWidth-1:0] rsp_read_rid_o,
-  output logic [NumBanks-1:0][RUserWidthAdjusted-1:0] rsp_read_ruser_o,
-  input  logic               [      AxiUserWidth-1:0] rsp_r_user_i
+  output logic [AxiUserWidth-1:0]                         rsp_read_ar_user_o,
+  output logic [    NumBanks-1:0]                         rsp_read_size_enable_o,
+  output logic [    NumBanks-1:0][    ObiCfg.IdWidth-1:0] rsp_read_rid_o,
+  output logic [    NumBanks-1:0][RUserWidthAdjusted-1:0] rsp_read_ruser_o,
+  input  logic [AxiUserWidth-1:0]                         rsp_r_user_i
 );
   typedef struct packed {
     logic [AxiIdWidth-1:0] atop_id;
@@ -85,7 +85,7 @@ module axi_to_obi #(
   axi_req_t axi_read_req, axi_write_req;
   axi_rsp_t axi_read_rsp, axi_write_rsp;
 
-  localparam int unsigned IdRuserWidth = ObiCfg.IdWidth+ObiCfg.OptionalCfg.RUserWidth;
+  localparam int unsigned IdRuserWidth = ObiCfg.IdWidth + ObiCfg.OptionalCfg.RUserWidth;
 
   logic            [2*NumBanks-1:0]                         bank_mem_req;
   logic            [2*NumBanks-1:0]                         bank_mem_gnt;
@@ -105,158 +105,158 @@ module axi_to_obi #(
   logic            [2*NumBanks-1:0]                         bank_mem_exokay;
   logic            [2*NumBanks-1:0][      IdRuserWidth-1:0] bank_mem_ruser;
 
-  logic [2*NumBanks-1:0][  IdRuserWidth-1:0] rsp_ruser;
-  logic [  NumBanks-1:0][2*AxiUserWidth-1:0] tmp_write_user;
+  logic            [2*NumBanks-1:0][      IdRuserWidth-1:0] rsp_ruser;
+  logic            [  NumBanks-1:0][    2*AxiUserWidth-1:0] tmp_write_user;
 
-  obi_req_t [2*NumBanks-1:0] obi_reqs;
-  obi_rsp_t [2*NumBanks-1:0] obi_rsps;
+  obi_req_t        [2*NumBanks-1:0]                         obi_reqs;
+  obi_rsp_t        [2*NumBanks-1:0]                         obi_rsps;
 
-  obi_pkg::atop_t [2*NumBanks-1:0] obi_atop;
+  obi_pkg::atop_t  [2*NumBanks-1:0]                         obi_atop;
 
   axi_demux_simple #(
-    .AxiIdWidth  ( AxiIdWidth ),
-    .AtopSupport ( 1'b1       ),
-    .axi_req_t   ( axi_req_t  ),
-    .axi_resp_t  ( axi_rsp_t  ),
-    .NoMstPorts  ( 2          ),
-    .MaxTrans    ( MaxTrans   ),
-    .AxiLookBits ( 1          ),
-    .UniqueIds   ( 1'b1       )
+    .AxiIdWidth (AxiIdWidth),
+    .AtopSupport(1'b1),
+    .axi_req_t  (axi_req_t),
+    .axi_resp_t (axi_rsp_t),
+    .NoMstPorts (2),
+    .MaxTrans   (MaxTrans),
+    .AxiLookBits(1),
+    .UniqueIds  (1'b1)
   ) i_read_write_demux (
     .clk_i,
     .rst_ni,
-    .test_i         ( testmode_i ),
-    .slv_req_i      ( axi_req_i  ),
-    .slv_resp_o     ( axi_rsp_o  ),
-    .slv_ar_select_i( 1'b0       ),
-    .slv_aw_select_i( 1'b1       ),
-    .mst_reqs_o     ( {axi_write_req, axi_read_req} ),
-    .mst_resps_i    ( {axi_write_rsp, axi_read_rsp} )
+    .test_i         (testmode_i),
+    .slv_req_i      (axi_req_i),
+    .slv_resp_o     (axi_rsp_o),
+    .slv_ar_select_i(1'b0),
+    .slv_aw_select_i(1'b1),
+    .mst_reqs_o     ({axi_write_req, axi_read_req}),
+    .mst_resps_i    ({axi_write_rsp, axi_read_rsp})
   );
 
   axi_to_detailed_mem_user #(
-    .axi_req_t   ( axi_req_t ),
-    .axi_resp_t  ( axi_rsp_t ),
-    .AddrWidth   ( AxiAddrWidth ),
-    .DataWidth   ( AxiDataWidth ),
-    .IdWidth     ( AxiIdWidth   ),
-    .UserWidth   ( AxiUserWidth ),
-    .NumBanks    ( NumBanks     ),
-    .BufDepth    ( MaxTrans     ),
-    .HideStrb    ( 1'b1         ),
-    .OutFifoDepth( 2            ),
-    .PropagateWUser ( 1'b0      ),
+    .axi_req_t     (axi_req_t),
+    .axi_resp_t    (axi_rsp_t),
+    .AddrWidth     (AxiAddrWidth),
+    .DataWidth     (AxiDataWidth),
+    .IdWidth       (AxiIdWidth),
+    .UserWidth     (AxiUserWidth),
+    .NumBanks      (NumBanks),
+    .BufDepth      (MaxTrans),
+    .HideStrb      (1'b1),
+    .OutFifoDepth  (2),
+    .PropagateWUser(1'b0),
     .RUserExtra    (IdRuserWidth)
   ) i_axi_to_mem_read (
     .clk_i,
     .rst_ni,
 
-    .busy_o      (),
+    .busy_o(),
 
-    .axi_req_i   ( axi_read_req ),
-    .axi_resp_o  ( axi_read_rsp ),
+    .axi_req_i (axi_read_req),
+    .axi_resp_o(axi_read_rsp),
 
-    .mem_req_o   ( bank_mem_req   [NumBanks-1:0] ),
-    .mem_gnt_i   ( bank_mem_gnt   [NumBanks-1:0] ),
-    .mem_addr_o  ( bank_mem_addr  [NumBanks-1:0] ),
-    .mem_wdata_o ( bank_mem_wdata [NumBanks-1:0] ),
-    .mem_strb_o  ( bank_mem_strb  [NumBanks-1:0] ),
-    .mem_atop_o  ( bank_mem_atop  [NumBanks-1:0] ),
-    .mem_lock_o  ( bank_mem_lock  [NumBanks-1:0] ),
-    .mem_we_o    (), // bank_mem_we    [NumBanks-1:0] ),
-    .mem_id_o    ( req_ar_id_o ), // bank_mem_id    [NumBanks-1:0] ),
-    .mem_user_o  ( req_ar_user_o ), // bank_mem_user  [NumBanks-1:0] ),
-    .mem_cache_o ( bank_mem_cache [NumBanks-1:0] ),
-    .mem_prot_o  ( bank_mem_prot  [NumBanks-1:0] ),
+    .mem_req_o   (bank_mem_req[NumBanks-1:0]),
+    .mem_gnt_i   (bank_mem_gnt[NumBanks-1:0]),
+    .mem_addr_o  (bank_mem_addr[NumBanks-1:0]),
+    .mem_wdata_o (bank_mem_wdata[NumBanks-1:0]),
+    .mem_strb_o  (bank_mem_strb[NumBanks-1:0]),
+    .mem_atop_o  (bank_mem_atop[NumBanks-1:0]),
+    .mem_lock_o  (bank_mem_lock[NumBanks-1:0]),
+    .mem_we_o    (),                               // bank_mem_we    [NumBanks-1:0] ),
+    .mem_id_o    (req_ar_id_o),                    // bank_mem_id    [NumBanks-1:0] ),
+    .mem_user_o  (req_ar_user_o),                  // bank_mem_user  [NumBanks-1:0] ),
+    .mem_cache_o (bank_mem_cache[NumBanks-1:0]),
+    .mem_prot_o  (bank_mem_prot[NumBanks-1:0]),
     .mem_qos_o   (),
     .mem_region_o(),
-    .mem_rvalid_i( bank_mem_rvalid[NumBanks-1:0] ),
-    .mem_rdata_i ( bank_mem_rdata [NumBanks-1:0] ),
-    .mem_err_i   ( bank_mem_err   [NumBanks-1:0] ),
-    .mem_exokay_i( bank_mem_exokay[NumBanks-1:0] ),
-    .mem_ruser_i ( bank_mem_ruser [NumBanks-1:0] ),
+    .mem_rvalid_i(bank_mem_rvalid[NumBanks-1:0]),
+    .mem_rdata_i (bank_mem_rdata[NumBanks-1:0]),
+    .mem_err_i   (bank_mem_err[NumBanks-1:0]),
+    .mem_exokay_i(bank_mem_exokay[NumBanks-1:0]),
+    .mem_ruser_i (bank_mem_ruser[NumBanks-1:0]),
 
-    .ruser_req_user_o       ( rsp_read_ar_user_o ),
+    .ruser_req_user_o       (rsp_read_ar_user_o),
     .ruser_req_bank_strb_o  (),
-    .ruser_req_size_enable_o( rsp_read_size_enable_o ),
-    .ruser_rsp_extra_o      ( rsp_ruser[NumBanks-1:0] ),
+    .ruser_req_size_enable_o(rsp_read_size_enable_o),
+    .ruser_rsp_extra_o      (rsp_ruser[NumBanks-1:0]),
     .ruser_req_write_o      (),
     .ruser_req_last_o       (),
     .ruser_rsp_hs_o         (),
-    .ruser_i                ( rsp_r_user_i )
+    .ruser_i                (rsp_r_user_i)
   );
-  assign bank_mem_we [NumBanks-1:0] = '0;
-  assign bank_mem_id [NumBanks-1:0] = req_read_aid_i;
-  assign bank_mem_user [NumBanks-1:0] = req_read_auser_i;
+  assign bank_mem_we[NumBanks-1:0]   = '0;
+  assign bank_mem_id[NumBanks-1:0]   = req_read_aid_i;
+  assign bank_mem_user[NumBanks-1:0] = req_read_auser_i;
 
   axi_to_detailed_mem_user #(
-    .axi_req_t   ( axi_req_t    ),
-    .axi_resp_t  ( axi_rsp_t    ),
-    .AddrWidth   ( AxiAddrWidth ),
-    .DataWidth   ( AxiDataWidth ),
-    .IdWidth     ( AxiIdWidth   ),
-    .UserWidth   ( AxiUserWidth ),
-    .NumBanks    ( NumBanks     ),
-    .BufDepth    ( MaxTrans     ),
-    .HideStrb    ( 1'b1         ),
-    .OutFifoDepth( 2            ),
+    .axi_req_t     (axi_req_t),
+    .axi_resp_t    (axi_rsp_t),
+    .AddrWidth     (AxiAddrWidth),
+    .DataWidth     (AxiDataWidth),
+    .IdWidth       (AxiIdWidth),
+    .UserWidth     (AxiUserWidth),
+    .NumBanks      (NumBanks),
+    .BufDepth      (MaxTrans),
+    .HideStrb      (1'b1),
+    .OutFifoDepth  (2),
     .PropagateWUser(1'b1),
     .RUserExtra    (IdRuserWidth)
   ) i_axi_to_mem_write (
     .clk_i,
     .rst_ni,
 
-    .busy_o      (),
+    .busy_o(),
 
-    .axi_req_i   ( axi_write_req ),
-    .axi_resp_o  ( axi_write_rsp ),
+    .axi_req_i (axi_write_req),
+    .axi_resp_o(axi_write_rsp),
 
-    .mem_req_o   ( bank_mem_req   [2*NumBanks-1:NumBanks] ),
-    .mem_gnt_i   ( bank_mem_gnt   [2*NumBanks-1:NumBanks] ),
-    .mem_addr_o  ( bank_mem_addr  [2*NumBanks-1:NumBanks] ),
-    .mem_wdata_o ( bank_mem_wdata [2*NumBanks-1:NumBanks] ),
-    .mem_strb_o  ( bank_mem_strb  [2*NumBanks-1:NumBanks] ),
-    .mem_atop_o  ( bank_mem_atop  [2*NumBanks-1:NumBanks] ),
-    .mem_lock_o  ( bank_mem_lock  [2*NumBanks-1:NumBanks] ),
-    .mem_we_o    (), // bank_mem_we    [2*NumBanks-1:NumBanks] ),
-    .mem_id_o    ( req_aw_id_o ), // bank_mem_id    [2*NumBanks-1:NumBanks] ),
-    .mem_user_o  ( tmp_write_user ), // bank_mem_user  [2*NumBanks-1:NumBanks] ),
-    .mem_cache_o ( bank_mem_cache [2*NumBanks-1:NumBanks] ),
-    .mem_prot_o  ( bank_mem_prot  [2*NumBanks-1:NumBanks] ),
-    .mem_qos_o   (),
+    .mem_req_o(bank_mem_req[2*NumBanks-1:NumBanks]),
+    .mem_gnt_i(bank_mem_gnt[2*NumBanks-1:NumBanks]),
+    .mem_addr_o(bank_mem_addr[2*NumBanks-1:NumBanks]),
+    .mem_wdata_o(bank_mem_wdata[2*NumBanks-1:NumBanks]),
+    .mem_strb_o(bank_mem_strb[2*NumBanks-1:NumBanks]),
+    .mem_atop_o(bank_mem_atop[2*NumBanks-1:NumBanks]),
+    .mem_lock_o(bank_mem_lock[2*NumBanks-1:NumBanks]),
+    .mem_we_o(),  // bank_mem_we    [2*NumBanks-1:NumBanks] ),
+    .mem_id_o(req_aw_id_o),  // bank_mem_id    [2*NumBanks-1:NumBanks] ),
+    .mem_user_o(tmp_write_user),  // bank_mem_user  [2*NumBanks-1:NumBanks] ),
+    .mem_cache_o(bank_mem_cache[2*NumBanks-1:NumBanks]),
+    .mem_prot_o(bank_mem_prot[2*NumBanks-1:NumBanks]),
+    .mem_qos_o(),
     .mem_region_o(),
-    .mem_rvalid_i( bank_mem_rvalid[2*NumBanks-1:NumBanks] ),
-    .mem_rdata_i ( bank_mem_rdata [2*NumBanks-1:NumBanks] ),
-    .mem_err_i   ( bank_mem_err   [2*NumBanks-1:NumBanks] ),
-    .mem_exokay_i( bank_mem_exokay[2*NumBanks-1:NumBanks] ),
-    .mem_ruser_i ( bank_mem_ruser [2*NumBanks-1:NumBanks] ),
+    .mem_rvalid_i(bank_mem_rvalid[2*NumBanks-1:NumBanks]),
+    .mem_rdata_i(bank_mem_rdata[2*NumBanks-1:NumBanks]),
+    .mem_err_i(bank_mem_err[2*NumBanks-1:NumBanks]),
+    .mem_exokay_i(bank_mem_exokay[2*NumBanks-1:NumBanks]),
+    .mem_ruser_i(bank_mem_ruser[2*NumBanks-1:NumBanks]),
 
-    .ruser_req_user_o       ( {rsp_write_w_user_o, rsp_write_aw_user_o} ),
-    .ruser_req_bank_strb_o  ( rsp_write_bank_strb_o ),
+    .ruser_req_user_o       ({rsp_write_w_user_o, rsp_write_aw_user_o}),
+    .ruser_req_bank_strb_o  (rsp_write_bank_strb_o),
     .ruser_req_size_enable_o(),
-    .ruser_rsp_extra_o      ( rsp_ruser[2*NumBanks-1:NumBanks] ),
+    .ruser_rsp_extra_o      (rsp_ruser[2*NumBanks-1:NumBanks]),
     .ruser_req_write_o      (),
-    .ruser_req_last_o       ( rsp_write_last_o ),
-    .ruser_rsp_hs_o         ( rsp_write_hs_o ),
-    .ruser_i                ( rsp_b_user_i )
+    .ruser_req_last_o       (rsp_write_last_o),
+    .ruser_rsp_hs_o         (rsp_write_hs_o),
+    .ruser_i                (rsp_b_user_i)
   );
-  assign bank_mem_we [2*NumBanks-1:NumBanks] = {NumBanks{1'b1}};
-  assign bank_mem_id    [2*NumBanks-1:NumBanks] = req_write_aid_i;
-  assign bank_mem_user  [2*NumBanks-1:NumBanks] = req_write_auser_i;
+  assign bank_mem_we[2*NumBanks-1:NumBanks]   = {NumBanks{1'b1}};
+  assign bank_mem_id[2*NumBanks-1:NumBanks]   = req_write_aid_i;
+  assign bank_mem_user[2*NumBanks-1:NumBanks] = req_write_auser_i;
 
   for (genvar i = 0; i < NumBanks; i++) begin : gen_user_rid
-    assign req_w_user_o[i] = tmp_write_user[i][2*AxiUserWidth-1:AxiUserWidth];
-    assign req_aw_user_o[i] = tmp_write_user[i][AxiUserWidth-1:0];
-    assign rsp_read_rid_o   [i] = rsp_ruser[         i][ObiCfg.IdWidth-1:0];
-    assign rsp_write_rid_o  [i] = rsp_ruser[NumBanks+i][ObiCfg.IdWidth-1:0];
+    assign req_w_user_o[i]    = tmp_write_user[i][2*AxiUserWidth-1:AxiUserWidth];
+    assign req_aw_user_o[i]   = tmp_write_user[i][AxiUserWidth-1:0];
+    assign rsp_read_rid_o[i]  = rsp_ruser[i][ObiCfg.IdWidth-1:0];
+    assign rsp_write_rid_o[i] = rsp_ruser[NumBanks+i][ObiCfg.IdWidth-1:0];
     if (ObiCfg.IdWidth > ObiCfg.IdWidth) begin : gen_user_resp
-    	assign rsp_read_ruser_o [i] = rsp_ruser[         i][IdRuserWidth-1:ObiCfg.IdWidth];
-    	assign rsp_write_ruser_o[i] = rsp_ruser[NumBanks+i][IdRuserWidth-1:ObiCfg.IdWidth];
+      assign rsp_read_ruser_o[i]  = rsp_ruser[i][IdRuserWidth-1:ObiCfg.IdWidth];
+      assign rsp_write_ruser_o[i] = rsp_ruser[NumBanks+i][IdRuserWidth-1:ObiCfg.IdWidth];
     end
   end
 
   if (ObiCfg.OptionalCfg.UseAtop) begin : gen_atop
-    for (genvar i = 0; i < 2*NumBanks; i++) begin : gen_atop_banks
+    for (genvar i = 0; i < 2 * NumBanks; i++) begin : gen_atop_banks
       always_comb begin : proc_atop_translate
         obi_atop[i] = obi_pkg::ATOPNONE;
         if (bank_mem_lock[i]) begin
@@ -265,15 +265,15 @@ module axi_to_obi #(
           obi_atop[i] = obi_pkg::AMOSWAP;
         end else if (bank_mem_atop[i] != '0) begin
           case (bank_mem_atop[i][2:0])
-            axi_pkg::ATOP_ADD: obi_atop[i] = obi_pkg::AMOADD;
-            axi_pkg::ATOP_EOR: obi_atop[i] = obi_pkg::AMOXOR;
-            axi_pkg::ATOP_CLR: obi_atop[i] = obi_pkg::AMOAND;
-            axi_pkg::ATOP_SET: obi_atop[i] = obi_pkg::AMOOR;
+            axi_pkg::ATOP_ADD:  obi_atop[i] = obi_pkg::AMOADD;
+            axi_pkg::ATOP_EOR:  obi_atop[i] = obi_pkg::AMOXOR;
+            axi_pkg::ATOP_CLR:  obi_atop[i] = obi_pkg::AMOAND;
+            axi_pkg::ATOP_SET:  obi_atop[i] = obi_pkg::AMOOR;
             axi_pkg::ATOP_SMIN: obi_atop[i] = obi_pkg::AMOMIN;
             axi_pkg::ATOP_SMAX: obi_atop[i] = obi_pkg::AMOMAX;
             axi_pkg::ATOP_UMIN: obi_atop[i] = obi_pkg::AMOMINU;
             axi_pkg::ATOP_UMAX: obi_atop[i] = obi_pkg::AMOMAXU;
-            default: ;
+            default:            ;
           endcase
         end
       end
@@ -282,10 +282,10 @@ module axi_to_obi #(
     assign obi_atop = '0;
   end
 
-  for (genvar i = 0; i < 2*NumBanks; i++) begin : gen_obi_bank_assign
-    assign obi_reqs[i].req     = bank_mem_req[i];
-    assign bank_mem_gnt[i]     = obi_rsps[i].gnt;
-    assign obi_reqs[i].a.addr  = bank_mem_addr[i];
+  for (genvar i = 0; i < 2 * NumBanks; i++) begin : gen_obi_bank_assign
+    assign obi_reqs[i].req    = bank_mem_req[i];
+    assign bank_mem_gnt[i]    = obi_rsps[i].gnt;
+    assign obi_reqs[i].a.addr = bank_mem_addr[i];
     if (ObiCfg.OptionalCfg.UseAtop) begin : gen_obi_bank_assign_atop
       assign obi_reqs[i].a.a_optional.atop = obi_atop[i];
       assign obi_reqs[i].a.wdata = (obi_atop[i] == obi_pkg::AMOAND) ?
@@ -293,13 +293,13 @@ module axi_to_obi #(
       assign bank_mem_exokay[i] = obi_rsps[i].r.r_optional.exokay;
     end else begin : gen_obi_bank_tie_atop
       assign obi_reqs[i].a.wdata = bank_mem_wdata[i];
-      assign bank_mem_exokay[i] = '0;
+      assign bank_mem_exokay[i]  = '0;
     end
-    assign obi_reqs[i].a.be    = bank_mem_strb[i];
-    assign obi_reqs[i].a.we    = bank_mem_we[i];
-    assign bank_mem_rvalid[i]  = obi_rsps[i].rvalid;
-    assign bank_mem_rdata[i]   = obi_rsps[i].r.rdata;
-    assign bank_mem_err[i]     = obi_rsps[i].r.err;
+    assign obi_reqs[i].a.be                      = bank_mem_strb[i];
+    assign obi_reqs[i].a.we                      = bank_mem_we[i];
+    assign bank_mem_rvalid[i]                    = obi_rsps[i].rvalid;
+    assign bank_mem_rdata[i]                     = obi_rsps[i].r.rdata;
+    assign bank_mem_err[i]                       = obi_rsps[i].r.err;
     assign bank_mem_ruser[i][ObiCfg.IdWidth-1:0] = obi_rsps[i].r.rid;
     if (ObiCfg.OptionalCfg.RUserWidth) begin : gen_ruser
       assign bank_mem_ruser[i][IdRuserWidth-1:ObiCfg.IdWidth] = obi_rsps[i].r.r_optional.ruser;
@@ -329,25 +329,25 @@ module axi_to_obi #(
   end
 
   obi_mux #(
-    .MgrPortObiCfg      ( ObiCfg       ),
-    .SbrPortObiCfg      ( ObiCfg       ),
-    .sbr_port_obi_req_t ( obi_req_t    ),
-    .sbr_port_obi_rsp_t ( obi_rsp_t    ),
-    .sbr_port_a_chan_t  ( obi_a_chan_t ),
-    .sbr_port_r_chan_t  ( obi_r_chan_t ),
-    .mgr_port_obi_req_t ( obi_req_t    ),
-    .mgr_port_obi_rsp_t ( obi_rsp_t    ),
-    .NumSbrPorts        ( 2*NumBanks   ),
-    .NumMaxTrans        ( MaxTrans     ),
-    .UseIdForRouting    ( 1'b0         )
+    .MgrPortObiCfg     (ObiCfg),
+    .SbrPortObiCfg     (ObiCfg),
+    .sbr_port_obi_req_t(obi_req_t),
+    .sbr_port_obi_rsp_t(obi_rsp_t),
+    .sbr_port_a_chan_t (obi_a_chan_t),
+    .sbr_port_r_chan_t (obi_r_chan_t),
+    .mgr_port_obi_req_t(obi_req_t),
+    .mgr_port_obi_rsp_t(obi_rsp_t),
+    .NumSbrPorts       (2 * NumBanks),
+    .NumMaxTrans       (MaxTrans),
+    .UseIdForRouting   (1'b0)
   ) i_mux_banks (
     .clk_i,
     .rst_ni,
     .testmode_i,
-    .sbr_ports_req_i( obi_reqs  ),
-    .sbr_ports_rsp_o( obi_rsps  ),
-    .mgr_port_req_o ( obi_req_o ),
-    .mgr_port_rsp_i ( obi_rsp_i )
+    .sbr_ports_req_i(obi_reqs),
+    .sbr_ports_rsp_o(obi_rsps),
+    .mgr_port_req_o (obi_req_o),
+    .mgr_port_rsp_i (obi_rsp_i)
   );
 
 endmodule

--- a/hw/axi_obi/src/obi_to_axi.sv
+++ b/hw/axi_obi/src/obi_to_axi.sv
@@ -1,0 +1,412 @@
+// Copyright 2023 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+// Michael Rogenmoser <michaero@iis.ee.ethz.ch>
+
+`include "common_cells/registers.svh"
+
+module obi_to_axi #(
+  /// The configuration of the OBI port (input port).
+  parameter obi_pkg::obi_cfg_t ObiCfg      = obi_pkg::ObiDefaultConfig,
+  /// The request struct of the OBI port
+  parameter type               obi_req_t = logic,
+  /// The response struct of the OBI port
+  parameter type               obi_rsp_t = logic,
+  /// Output is AXI lite when set to 1'b1
+  parameter bit                AxiLite      = 1'b0,
+  /// AXI Address Width
+  parameter int unsigned       AxiAddrWidth = ObiCfg.AddrWidth,
+  /// AXI Data Width
+  parameter int unsigned       AxiDataWidth = ObiCfg.DataWidth,
+  /// AXI User Width, manually assigned from the outside, applied to Ax
+  parameter int unsigned       AxiUserWidth = 0,
+  /// AXI Burst Type (burst unused but may be required for IP compatibility)
+  parameter int unsigned       AxiBurstType = axi_pkg::BURST_INCR,
+  /// The request struct of the AXI port
+  parameter type               axi_req_t = logic,
+  /// The response struct of the AXI port
+  parameter type               axi_rsp_t = logic,
+  parameter int unsigned       MaxRequests = 0
+) (
+  input  logic     clk_i,
+  input  logic     rst_ni,
+
+  input  obi_req_t obi_req_i,
+  output obi_rsp_t obi_rsp_o,
+  input  logic [AxiUserWidth-1:0] user_i,
+
+  output axi_req_t axi_req_o,
+  input  axi_rsp_t axi_rsp_i,
+
+  // Signals for manual user reassignment of response
+  output logic [1:0]              axi_rsp_channel_sel, // [ATOP , WE]
+  output logic [AxiUserWidth-1:0] axi_rsp_b_user_o,
+  output logic [AxiUserWidth-1:0] axi_rsp_r_user_o,
+  input  logic [ObiCfg.OptionalCfg.RUserWidth-1:0] obi_rsp_user_i // If unused tie to '0
+);
+
+  localparam int unsigned AxiSize = axi_pkg::size_t'($unsigned($clog2(ObiCfg.DataWidth/8)));
+  localparam bit [2:0] DefaultProt = 3'b100; // OBI default is 3'b111
+
+  typedef logic [AxiAddrWidth-1:0] axi_addr_t;
+
+  logic [$clog2(AxiDataWidth/ObiCfg.DataWidth)-1:0] data_offset, rdata_offset;
+
+  // Response FIFO control signals.
+  logic fifo_full, fifo_empty;
+  // Bookkeeping for sent write beats.
+  logic aw_sent_q, aw_sent_d;
+  logic w_sent_q,  w_sent_d;
+
+  logic [2:0] axi_obi_prot;
+  logic       axi_obi_lock;
+  logic [5:0] axi_obi_atop;
+  logic [ObiCfg.DataWidth-1:0] axi_obi_wdata;
+  logic [3:0] axi_obi_cache;
+
+  if (ObiCfg.OptionalCfg.UseProt) begin : gen_prot
+    // User mode is unpriviledged
+    assign axi_obi_prot[0]  = obi_req_i.a.a_optional.prot[2:1] != 2'b00;
+    // Always secure?
+    assign axi_obi_prot[1]  = 1'b0;
+    // Instr / Data access
+    assign axi_obi_prot[2]  = ~obi_req_i.a.a_optional.prot[0];
+  end else begin : gen_default_prot
+    assign axi_obi_prot = DefaultProt;
+  end
+
+  if (ObiCfg.OptionalCfg.UseAtop) begin : gen_atop
+    always_comb begin : proc_atop_translate
+      axi_obi_lock = 1'b0;
+      axi_obi_atop = '0;
+      axi_obi_wdata = obi_req_i.a.wdata;
+      case (obi_req_i.a.a_optional.atop)
+        obi_pkg::ATOPLR:  axi_obi_lock = 1'b1;
+        obi_pkg::ATOPSC:  axi_obi_lock = 1'b1;
+        obi_pkg::AMOSWAP: axi_obi_atop = {axi_pkg::ATOP_ATOMICSWAP};
+        obi_pkg::AMOADD:  axi_obi_atop = {axi_pkg::ATOP_ATOMICLOAD,
+                                          axi_pkg::ATOP_LITTLE_END,
+                                          axi_pkg::ATOP_ADD};
+        obi_pkg::AMOXOR:  axi_obi_atop = {axi_pkg::ATOP_ATOMICLOAD,
+                                          axi_pkg::ATOP_LITTLE_END,
+                                          axi_pkg::ATOP_EOR};
+        obi_pkg::AMOAND: begin
+          axi_obi_atop = {axi_pkg::ATOP_ATOMICLOAD,
+                          axi_pkg::ATOP_LITTLE_END,
+                          axi_pkg::ATOP_CLR};
+          axi_obi_wdata = ~obi_req_i.a.wdata;
+        end
+        obi_pkg::AMOOR:   axi_obi_atop = {axi_pkg::ATOP_ATOMICLOAD,
+                                          axi_pkg::ATOP_LITTLE_END,
+                                          axi_pkg::ATOP_SET};
+        obi_pkg::AMOMIN:  axi_obi_atop = {axi_pkg::ATOP_ATOMICLOAD,
+                                          axi_pkg::ATOP_LITTLE_END,
+                                          axi_pkg::ATOP_SMIN};
+        obi_pkg::AMOMAX:  axi_obi_atop = {axi_pkg::ATOP_ATOMICLOAD,
+                                          axi_pkg::ATOP_LITTLE_END,
+                                          axi_pkg::ATOP_SMAX};
+        obi_pkg::AMOMINU: axi_obi_atop = {axi_pkg::ATOP_ATOMICLOAD,
+                                          axi_pkg::ATOP_LITTLE_END,
+                                          axi_pkg::ATOP_UMIN};
+        obi_pkg::AMOMAXU: axi_obi_atop = {axi_pkg::ATOP_ATOMICLOAD,
+                                          axi_pkg::ATOP_LITTLE_END,
+                                          axi_pkg::ATOP_UMAX};
+        default:;
+      endcase
+    end
+  end else begin : gen_tie_atop
+    assign axi_obi_lock = '0;
+    assign axi_obi_atop = '0;
+    assign axi_obi_wdata = obi_req_i.a.wdata;
+  end
+  if (ObiCfg.OptionalCfg.UseMemtype) begin : gen_memtype
+    always_comb begin : proc_memtype_translate
+      axi_obi_cache = 4'b0010;
+      if (obi_req_i.a.a_optional.memtype[0]) begin // Bufferable
+        axi_obi_cache[0] = 1'b1;
+      end
+      if (obi_req_i.a.a_optional.memtype[1]) begin // Cacheable
+        axi_obi_cache[1] = 1'b0;
+      end
+    end
+  end else begin : gen_tie_memtype
+    assign axi_obi_cache = 4'b0010;
+  end
+
+  // AW Assignment
+  if (AxiLite) begin : gen_axi_lite_aw
+    always_comb begin : proc_aw_lite_assign
+      // Default assignments.
+      axi_req_o.aw       = '0;
+      axi_req_o.aw.addr  = axi_addr_t'(obi_req_i.a.addr);
+      axi_req_o.aw.prot  = axi_obi_prot;
+    end
+  end else begin : gen_axi_full_aw
+    always_comb begin : proc_aw_assign
+      // Default assignments.
+      axi_req_o.aw       = '0;
+      axi_req_o.aw.addr  = axi_addr_t'(obi_req_i.a.addr);
+      axi_req_o.aw.prot  = axi_obi_prot;
+      // AXI-Lite assignments.
+      axi_req_o.aw.size  = AxiSize;
+      axi_req_o.aw.burst = AxiBurstType;
+      axi_req_o.aw.lock  = axi_obi_lock;
+      axi_req_o.aw.atop  = axi_obi_atop;
+      axi_req_o.aw.cache = axi_obi_cache;
+      axi_req_o.aw.user  = user_i;
+    end
+  end
+
+  // W Assignment
+  if (AxiLite) begin : gen_axi_lite_w
+    always_comb begin : proc_w_lite_assign
+      axi_req_o.w        = '0;
+      axi_req_o.w.data[ObiCfg.DataWidth*data_offset+:ObiCfg.DataWidth] = axi_obi_wdata;
+      axi_req_o.w.strb[ObiCfg.DataWidth/8*data_offset+:ObiCfg.DataWidth/8] = obi_req_i.a.be;
+    end
+  end else begin : gen_axi_full_w
+    always_comb begin : proc_w_assign
+      axi_req_o.w        = '0;
+      axi_req_o.w.data[ObiCfg.DataWidth*data_offset+:ObiCfg.DataWidth] = axi_obi_wdata;
+      axi_req_o.w.strb[ObiCfg.DataWidth/8*data_offset+:ObiCfg.DataWidth/8] = obi_req_i.a.be;
+      axi_req_o.w.last = 1'b1;
+    end
+  end
+
+  // AR Assignment
+  if (AxiLite) begin : gen_axi_lite_ar
+    always_comb begin : proc_ar_lite_assign
+      axi_req_o.ar       = '0;
+      axi_req_o.ar.addr  = axi_addr_t'(obi_req_i.a.addr);
+      axi_req_o.ar.prot  = axi_obi_prot;
+    end
+  end else begin : gen_axi_full_ar
+    always_comb begin : proc_ar_assign
+      axi_req_o.ar       = '0;
+      axi_req_o.ar.addr  = axi_addr_t'(obi_req_i.a.addr);
+      axi_req_o.ar.prot  = axi_obi_prot;
+      axi_req_o.ar.size  = AxiSize;
+      axi_req_o.ar.burst = AxiBurstType;
+      axi_req_o.ar.lock  = axi_obi_lock;
+      axi_req_o.ar.cache = axi_obi_cache;
+      // User signals?
+    end
+  end
+
+  // Control for translating request to the AXI4-Lite `AW`, `W` and `AR` channels.
+  always_comb begin : proc_request_control
+    data_offset = '0;
+    if (AxiDataWidth > ObiCfg.DataWidth) begin
+      data_offset = obi_req_i.a.addr[$clog2(ObiCfg.DataWidth/8)+:
+                                     $clog2(AxiDataWidth/ObiCfg.DataWidth)];
+    end
+    axi_req_o.aw_valid = 1'b0;
+    axi_req_o.w_valid  = 1'b0;
+    axi_req_o.ar_valid = 1'b0;
+    // This is also the push signal for the response FIFO.
+    obi_rsp_o.gnt      = 1'b0;
+    // Bookkeeping about sent write channels.
+    aw_sent_d          = aw_sent_q;
+    w_sent_d           = w_sent_q;
+
+    // Control for Request to AXI4-Lite translation.
+    if (obi_req_i.req && !fifo_full) begin
+      if (!obi_req_i.a.we) begin
+        // It is a read request.
+        axi_req_o.ar_valid = 1'b1;
+        obi_rsp_o.gnt          = axi_rsp_i.ar_ready;
+      end else begin
+        // Is is a write request, decouple `AW` and `W` channels.
+        unique case ({aw_sent_q, w_sent_q})
+          2'b00 : begin
+            // None of the AXI4-Lite writes have been sent jet.
+            axi_req_o.aw_valid = 1'b1;
+            axi_req_o.w_valid  = 1'b1;
+            unique case ({axi_rsp_i.aw_ready, axi_rsp_i.w_ready})
+              2'b01 : begin // W is sent, still needs AW.
+                w_sent_d = 1'b1;
+              end
+              2'b10 : begin // AW is sent, still needs W.
+                aw_sent_d = 1'b1;
+              end
+              2'b11 : begin // Both are transmitted, grant the write request.
+                obi_rsp_o.gnt = 1'b1;
+              end
+              default : /* do nothing */;
+            endcase
+          end
+          2'b10 : begin
+            // W has to be sent.
+            axi_req_o.w_valid = 1'b1;
+            if (axi_rsp_i.w_ready) begin
+              aw_sent_d = 1'b0;
+              obi_rsp_o.gnt = 1'b1;
+            end
+          end
+          2'b01 : begin
+            // AW has to be sent.
+            axi_req_o.aw_valid = 1'b1;
+            if (axi_rsp_i.aw_ready) begin
+              w_sent_d  = 1'b0;
+              obi_rsp_o.gnt = 1'b1;
+            end
+          end
+          default : begin
+            // Failsafe go to IDLE.
+            aw_sent_d = 1'b0;
+            w_sent_d  = 1'b0;
+          end
+        endcase
+      end
+    end
+  end
+
+  `FFARN(aw_sent_q, aw_sent_d, 1'b0, clk_i, rst_ni)
+  `FFARN(w_sent_q, w_sent_d, 1'b0, clk_i, rst_ni)
+
+  // Select which response should be forwarded. `01` write response, `00` read response, `11` for atomics.
+  logic [1:0] rsp_sel;
+
+  fifo_v3 #(
+    .FALL_THROUGH ( 1'b0        ), // No fallthrough for one cycle delay before ready on AXI.
+    .DEPTH        ( MaxRequests ),
+    .dtype        ( logic[1:0]  )
+  ) i_fifo_rsp_mux (
+    .clk_i,
+    .rst_ni,
+    .flush_i    ( 1'b0             ),
+    .testmode_i ( 1'b0             ),
+    .full_o     ( fifo_full        ),
+    .empty_o    ( fifo_empty       ),
+    .usage_o    ( /*not used*/     ),
+    .data_i     ( {|axi_obi_atop, obi_req_i.a.we} ),
+    .push_i     ( obi_rsp_o.gnt    ),
+    .data_o     ( rsp_sel          ),
+    .pop_i      ( obi_rsp_o.rvalid )
+  );
+
+  fifo_v3 #(
+    .FALL_THROUGH ( 1'b0        ), // No fallthrough for one cycle delay before ready on AXI.
+    .DEPTH        ( MaxRequests ),
+    .dtype        ( logic[ObiCfg.IdWidth-1:0] )
+  ) i_fifo_rid (
+    .clk_i,
+    .rst_ni,
+    .flush_i    ( 1'b0             ),
+    .testmode_i ( 1'b0             ),
+    .full_o     (),// rsp_mux flow control used
+    .empty_o    (),// rsp_mux flow control used
+    .usage_o    (),// rsp_mux flow control used
+    .data_i     ( obi_req_i.a.aid  ),
+    .push_i     ( obi_rsp_o.gnt    ),// rsp_mux flow control used
+    .data_o     ( obi_rsp_o.r.rid  ),
+    .pop_i      ( obi_rsp_o.rvalid )// rsp_mux flow control used
+  );
+
+  localparam int unsigned NumObiChans = AxiDataWidth/ObiCfg.DataWidth;
+  localparam int unsigned NumObiChanWidth = $clog2(NumObiChans);
+
+  typedef logic[NumObiChanWidth-1:0] obi_chan_sel_t;
+
+
+  if (AxiDataWidth > ObiCfg.DataWidth) begin : gen_datawidth_offset_fifo
+    fifo_v3 #(
+      .FALL_THROUGH ( 1'b0        ), // No fallthrough for one cycle delay before ready on AXI.
+      .DEPTH        ( MaxRequests ),
+      .dtype        ( obi_chan_sel_t  )
+    ) i_fifo_size (
+      .clk_i,
+      .rst_ni,
+      .flush_i    ( 1'b0             ),
+      .testmode_i ( 1'b0             ),
+      .full_o     (),// rsp_mux flow control used
+      .empty_o    (),// rsp_mux flow control used
+      .usage_o    (),// rsp_mux flow control used
+      .data_i     ( data_offset      ),
+      .push_i     ( obi_rsp_o.gnt    ),// rsp_mux flow control used
+      .data_o     ( rdata_offset     ),
+      .pop_i      ( obi_rsp_o.rvalid )// rsp_mux flow control used
+    );
+  end else begin : gen_no_datawidth_offset
+    assign rdata_offset = '0;
+  end
+
+  // Response selection control.
+  // If something is in the FIFO, the corresponding channel is ready.
+  assign axi_req_o.b_ready = ~fifo_empty &
+                             (( rsp_sel[0] & ~rsp_sel[1]) | (rsp_sel[1] & axi_rsp_i.r_valid));
+  assign axi_req_o.r_ready = ~fifo_empty &
+                             ((~rsp_sel[0] & ~rsp_sel[1]) | (rsp_sel[1] & axi_rsp_i.b_valid));
+  // Read data is directly forwarded.
+  assign obi_rsp_o.r.rdata = axi_rsp_i.r.data[ObiCfg.DataWidth*rdata_offset+:ObiCfg.DataWidth];
+  // Error is taken from the respective channel.
+  assign obi_rsp_o.r.err = rsp_sel[1] ?
+      (axi_rsp_i.b.resp inside {axi_pkg::RESP_SLVERR, axi_pkg::RESP_DECERR}) |
+      (axi_rsp_i.r.resp inside {axi_pkg::RESP_SLVERR, axi_pkg::RESP_DECERR}) :
+      rsp_sel[0] ?
+          (axi_rsp_i.b.resp inside {axi_pkg::RESP_SLVERR, axi_pkg::RESP_DECERR}) :
+          (axi_rsp_i.r.resp inside {axi_pkg::RESP_SLVERR, axi_pkg::RESP_DECERR});
+  // EXOKAY if needed is passed
+  if (ObiCfg.OptionalCfg.UseAtop) begin : gen_atop_exokay
+    assign obi_rsp_o.r.r_optional.exokay = rsp_sel[0] ?
+      (axi_rsp_i.b.resp == axi_pkg::RESP_EXOKAY) :
+      (axi_rsp_i.r.resp == axi_pkg::RESP_EXOKAY);
+  end
+  // User signal concatenation is handled outside
+  assign axi_rsp_b_user_o = axi_rsp_i.b.user;
+  assign axi_rsp_r_user_o = axi_rsp_i.r.user;
+  assign axi_rsp_channel_sel = rsp_sel;
+  if (ObiCfg.OptionalCfg.RUserWidth) begin : gen_ruser
+    assign obi_rsp_o.r.r_optional.ruser = obi_rsp_user_i;
+  end
+  // Mem response is valid if the handshaking on the respective channel occurs.
+  // Can not happen at the same time as ready is set from the FIFO.
+  // This serves as the pop signal for the FIFO.
+  assign obi_rsp_o.rvalid = (axi_rsp_i.b_valid & axi_req_o.b_ready) |
+                           (axi_rsp_i.r_valid & axi_req_o.r_ready);
+
+  // pragma translate_off
+  `ifndef SYNTHESIS
+  `ifndef VERILATOR
+    initial begin : proc_assert
+      if (AxiLite) begin
+        assert (ObiCfg.OptionalCfg.UseAtop == 0) else $fatal(1, "ATOP not supported in AXI lite");
+        assert (ObiCfg.OptionalCfg.UseMemtype == 0) else
+          $fatal(1, "Memtype/cache not supported in AXI lite");
+      end
+      assert (ObiCfg.AddrWidth > 32'd0) else $fatal(1, "OBI AddrWidth has to be greater than 0!");
+      assert (AxiAddrWidth > 32'd0) else $fatal(1, "AxiAddrWidth has to be greater than 0!");
+      assert (ObiCfg.DataWidth <= AxiDataWidth && AxiDataWidth % ObiCfg.DataWidth == 0) else
+          $fatal(1, "DataWidth has to be proper divisor of and <= AxiDataWidth!");
+      assert (MaxRequests > 32'd0) else $fatal(1, "MaxRequests has to be greater than 0!");
+      assert (AxiAddrWidth == $bits(axi_req_o.aw.addr)) else
+          $fatal(1, "AxiAddrWidth has to match axi_req_o.aw.addr!");
+      assert (AxiAddrWidth == $bits(axi_req_o.ar.addr)) else
+          $fatal(1, "AxiAddrWidth has to match axi_req_o.ar.addr!");
+      // assert (DataWidth == $bits(axi_req_o.w.data)) else
+      //     $fatal(1, "DataWidth has to match axi_req_o.w.data!");
+      // assert (DataWidth/8 == $bits(axi_req_o.w.strb)) else
+      //     $fatal(1, "DataWidth / 8 has to match axi_req_o.w.strb!");
+      // assert (DataWidth == $bits(axi_rsp_i.r.data)) else
+      //     $fatal(1, "DataWidth has to match axi_rsp_i.r.data!");
+    end
+    default disable iff (~rst_ni);
+    assert property (@(posedge clk_i) (obi_req_i.req && !obi_rsp_o.gnt) |=> obi_req_i.req) else
+        $fatal(1, "It is not allowed to deassert the request if it was not granted!");
+    assert property (@(posedge clk_i) (obi_req_i.req && !obi_rsp_o.gnt) |=>
+                                       $stable(obi_req_i.a.addr)) else
+        $fatal(1, "obi_req_i.a.addr has to be stable if request is not granted!");
+    assert property (@(posedge clk_i) (obi_req_i.req && !obi_rsp_o.gnt) |=>
+                                       $stable(obi_req_i.a.we)) else
+        $fatal(1, "obi_req_i.a.we has to be stable if request is not granted!");
+    assert property (@(posedge clk_i) (obi_req_i.req && !obi_rsp_o.gnt) |=>
+                                       $stable(obi_req_i.a.wdata)) else
+        $fatal(1, "obi_req_i.a.wdata has to be stable if request is not granted!");
+    assert property (@(posedge clk_i) (obi_req_i.req && !obi_rsp_o.gnt) |=>
+                                       $stable(obi_req_i.a.be)) else
+        $fatal(1, "obi_req_i.a.be has to be stable if request is not granted!");
+  `endif
+  `endif
+  // pragma translate_on
+endmodule

--- a/hw/axi_obi/src/obi_to_axi.sv
+++ b/hw/axi_obi/src/obi_to_axi.sv
@@ -8,11 +8,11 @@
 
 module obi_to_axi #(
   /// The configuration of the OBI port (input port).
-  parameter obi_pkg::obi_cfg_t ObiCfg      = obi_pkg::ObiDefaultConfig,
+  parameter obi_pkg::obi_cfg_t ObiCfg       = obi_pkg::ObiDefaultConfig,
   /// The request struct of the OBI port
-  parameter type               obi_req_t = logic,
+  parameter type               obi_req_t    = logic,
   /// The response struct of the OBI port
-  parameter type               obi_rsp_t = logic,
+  parameter type               obi_rsp_t    = logic,
   /// Output is AXI lite when set to 1'b1
   parameter bit                AxiLite      = 1'b0,
   /// AXI Address Width
@@ -24,30 +24,30 @@ module obi_to_axi #(
   /// AXI Burst Type (burst unused but may be required for IP compatibility)
   parameter int unsigned       AxiBurstType = axi_pkg::BURST_INCR,
   /// The request struct of the AXI port
-  parameter type               axi_req_t = logic,
+  parameter type               axi_req_t    = logic,
   /// The response struct of the AXI port
-  parameter type               axi_rsp_t = logic,
-  parameter int unsigned       MaxRequests = 0
+  parameter type               axi_rsp_t    = logic,
+  parameter int unsigned       MaxRequests  = 0
 ) (
-  input  logic     clk_i,
-  input  logic     rst_ni,
+  input logic clk_i,
+  input logic rst_ni,
 
-  input  obi_req_t obi_req_i,
-  output obi_rsp_t obi_rsp_o,
-  input  logic [AxiUserWidth-1:0] user_i,
+  input  obi_req_t                    obi_req_i,
+  output obi_rsp_t                    obi_rsp_o,
+  input  logic     [AxiUserWidth-1:0] user_i,
 
   output axi_req_t axi_req_o,
   input  axi_rsp_t axi_rsp_i,
 
   // Signals for manual user reassignment of response
-  output logic [1:0]              axi_rsp_channel_sel, // [ATOP , WE]
-  output logic [AxiUserWidth-1:0] axi_rsp_b_user_o,
-  output logic [AxiUserWidth-1:0] axi_rsp_r_user_o,
-  input  logic [ObiCfg.OptionalCfg.RUserWidth-1:0] obi_rsp_user_i // If unused tie to '0
+  output logic [                              1:0] axi_rsp_channel_sel,  // [ATOP , WE]
+  output logic [                 AxiUserWidth-1:0] axi_rsp_b_user_o,
+  output logic [                 AxiUserWidth-1:0] axi_rsp_r_user_o,
+  input  logic [ObiCfg.OptionalCfg.RUserWidth-1:0] obi_rsp_user_i        // If unused tie to '0
 );
 
-  localparam int unsigned AxiSize = axi_pkg::size_t'($unsigned($clog2(ObiCfg.DataWidth/8)));
-  localparam bit [2:0] DefaultProt = 3'b100; // OBI default is 3'b111
+  localparam int unsigned AxiSize = axi_pkg::size_t'($unsigned($clog2(ObiCfg.DataWidth / 8)));
+  localparam bit [2:0] DefaultProt = 3'b100;  // OBI default is 3'b111
 
   typedef logic [AxiAddrWidth-1:0] axi_addr_t;
 
@@ -57,76 +57,67 @@ module obi_to_axi #(
   logic fifo_full, fifo_empty;
   // Bookkeeping for sent write beats.
   logic aw_sent_q, aw_sent_d;
-  logic w_sent_q,  w_sent_d;
+  logic w_sent_q, w_sent_d;
 
-  logic [2:0] axi_obi_prot;
-  logic       axi_obi_lock;
-  logic [5:0] axi_obi_atop;
+  logic [                 2:0] axi_obi_prot;
+  logic                        axi_obi_lock;
+  logic [                 5:0] axi_obi_atop;
   logic [ObiCfg.DataWidth-1:0] axi_obi_wdata;
-  logic [3:0] axi_obi_cache;
+  logic [                 3:0] axi_obi_cache;
 
   if (ObiCfg.OptionalCfg.UseProt) begin : gen_prot
     // User mode is unpriviledged
-    assign axi_obi_prot[0]  = obi_req_i.a.a_optional.prot[2:1] != 2'b00;
+    assign axi_obi_prot[0] = obi_req_i.a.a_optional.prot[2:1] != 2'b00;
     // Always secure?
-    assign axi_obi_prot[1]  = 1'b0;
+    assign axi_obi_prot[1] = 1'b0;
     // Instr / Data access
-    assign axi_obi_prot[2]  = ~obi_req_i.a.a_optional.prot[0];
+    assign axi_obi_prot[2] = ~obi_req_i.a.a_optional.prot[0];
   end else begin : gen_default_prot
     assign axi_obi_prot = DefaultProt;
   end
 
   if (ObiCfg.OptionalCfg.UseAtop) begin : gen_atop
     always_comb begin : proc_atop_translate
-      axi_obi_lock = 1'b0;
-      axi_obi_atop = '0;
+      axi_obi_lock  = 1'b0;
+      axi_obi_atop  = '0;
       axi_obi_wdata = obi_req_i.a.wdata;
       case (obi_req_i.a.a_optional.atop)
-        obi_pkg::ATOPLR:  axi_obi_lock = 1'b1;
-        obi_pkg::ATOPSC:  axi_obi_lock = 1'b1;
+        obi_pkg::ATOPLR: axi_obi_lock = 1'b1;
+        obi_pkg::ATOPSC: axi_obi_lock = 1'b1;
         obi_pkg::AMOSWAP: axi_obi_atop = {axi_pkg::ATOP_ATOMICSWAP};
-        obi_pkg::AMOADD:  axi_obi_atop = {axi_pkg::ATOP_ATOMICLOAD,
-                                          axi_pkg::ATOP_LITTLE_END,
-                                          axi_pkg::ATOP_ADD};
-        obi_pkg::AMOXOR:  axi_obi_atop = {axi_pkg::ATOP_ATOMICLOAD,
-                                          axi_pkg::ATOP_LITTLE_END,
-                                          axi_pkg::ATOP_EOR};
+        obi_pkg::AMOADD:
+        axi_obi_atop = {axi_pkg::ATOP_ATOMICLOAD, axi_pkg::ATOP_LITTLE_END, axi_pkg::ATOP_ADD};
+        obi_pkg::AMOXOR:
+        axi_obi_atop = {axi_pkg::ATOP_ATOMICLOAD, axi_pkg::ATOP_LITTLE_END, axi_pkg::ATOP_EOR};
         obi_pkg::AMOAND: begin
-          axi_obi_atop = {axi_pkg::ATOP_ATOMICLOAD,
-                          axi_pkg::ATOP_LITTLE_END,
-                          axi_pkg::ATOP_CLR};
+          axi_obi_atop  = {axi_pkg::ATOP_ATOMICLOAD, axi_pkg::ATOP_LITTLE_END, axi_pkg::ATOP_CLR};
           axi_obi_wdata = ~obi_req_i.a.wdata;
         end
-        obi_pkg::AMOOR:   axi_obi_atop = {axi_pkg::ATOP_ATOMICLOAD,
-                                          axi_pkg::ATOP_LITTLE_END,
-                                          axi_pkg::ATOP_SET};
-        obi_pkg::AMOMIN:  axi_obi_atop = {axi_pkg::ATOP_ATOMICLOAD,
-                                          axi_pkg::ATOP_LITTLE_END,
-                                          axi_pkg::ATOP_SMIN};
-        obi_pkg::AMOMAX:  axi_obi_atop = {axi_pkg::ATOP_ATOMICLOAD,
-                                          axi_pkg::ATOP_LITTLE_END,
-                                          axi_pkg::ATOP_SMAX};
-        obi_pkg::AMOMINU: axi_obi_atop = {axi_pkg::ATOP_ATOMICLOAD,
-                                          axi_pkg::ATOP_LITTLE_END,
-                                          axi_pkg::ATOP_UMIN};
-        obi_pkg::AMOMAXU: axi_obi_atop = {axi_pkg::ATOP_ATOMICLOAD,
-                                          axi_pkg::ATOP_LITTLE_END,
-                                          axi_pkg::ATOP_UMAX};
-        default:;
+        obi_pkg::AMOOR:
+        axi_obi_atop = {axi_pkg::ATOP_ATOMICLOAD, axi_pkg::ATOP_LITTLE_END, axi_pkg::ATOP_SET};
+        obi_pkg::AMOMIN:
+        axi_obi_atop = {axi_pkg::ATOP_ATOMICLOAD, axi_pkg::ATOP_LITTLE_END, axi_pkg::ATOP_SMIN};
+        obi_pkg::AMOMAX:
+        axi_obi_atop = {axi_pkg::ATOP_ATOMICLOAD, axi_pkg::ATOP_LITTLE_END, axi_pkg::ATOP_SMAX};
+        obi_pkg::AMOMINU:
+        axi_obi_atop = {axi_pkg::ATOP_ATOMICLOAD, axi_pkg::ATOP_LITTLE_END, axi_pkg::ATOP_UMIN};
+        obi_pkg::AMOMAXU:
+        axi_obi_atop = {axi_pkg::ATOP_ATOMICLOAD, axi_pkg::ATOP_LITTLE_END, axi_pkg::ATOP_UMAX};
+        default: ;
       endcase
     end
   end else begin : gen_tie_atop
-    assign axi_obi_lock = '0;
-    assign axi_obi_atop = '0;
+    assign axi_obi_lock  = '0;
+    assign axi_obi_atop  = '0;
     assign axi_obi_wdata = obi_req_i.a.wdata;
   end
   if (ObiCfg.OptionalCfg.UseMemtype) begin : gen_memtype
     always_comb begin : proc_memtype_translate
       axi_obi_cache = 4'b0010;
-      if (obi_req_i.a.a_optional.memtype[0]) begin // Bufferable
+      if (obi_req_i.a.a_optional.memtype[0]) begin  // Bufferable
         axi_obi_cache[0] = 1'b1;
       end
-      if (obi_req_i.a.a_optional.memtype[1]) begin // Cacheable
+      if (obi_req_i.a.a_optional.memtype[1]) begin  // Cacheable
         axi_obi_cache[1] = 1'b0;
       end
     end
@@ -138,9 +129,9 @@ module obi_to_axi #(
   if (AxiLite) begin : gen_axi_lite_aw
     always_comb begin : proc_aw_lite_assign
       // Default assignments.
-      axi_req_o.aw       = '0;
-      axi_req_o.aw.addr  = axi_addr_t'(obi_req_i.a.addr);
-      axi_req_o.aw.prot  = axi_obi_prot;
+      axi_req_o.aw      = '0;
+      axi_req_o.aw.addr = axi_addr_t'(obi_req_i.a.addr);
+      axi_req_o.aw.prot = axi_obi_prot;
     end
   end else begin : gen_axi_full_aw
     always_comb begin : proc_aw_assign
@@ -161,25 +152,25 @@ module obi_to_axi #(
   // W Assignment
   if (AxiLite) begin : gen_axi_lite_w
     always_comb begin : proc_w_lite_assign
-      axi_req_o.w        = '0;
-      axi_req_o.w.data[ObiCfg.DataWidth*data_offset+:ObiCfg.DataWidth] = axi_obi_wdata;
+      axi_req_o.w                                                          = '0;
+      axi_req_o.w.data[ObiCfg.DataWidth*data_offset+:ObiCfg.DataWidth]     = axi_obi_wdata;
       axi_req_o.w.strb[ObiCfg.DataWidth/8*data_offset+:ObiCfg.DataWidth/8] = obi_req_i.a.be;
     end
   end else begin : gen_axi_full_w
     always_comb begin : proc_w_assign
-      axi_req_o.w        = '0;
-      axi_req_o.w.data[ObiCfg.DataWidth*data_offset+:ObiCfg.DataWidth] = axi_obi_wdata;
+      axi_req_o.w                                                          = '0;
+      axi_req_o.w.data[ObiCfg.DataWidth*data_offset+:ObiCfg.DataWidth]     = axi_obi_wdata;
       axi_req_o.w.strb[ObiCfg.DataWidth/8*data_offset+:ObiCfg.DataWidth/8] = obi_req_i.a.be;
-      axi_req_o.w.last = 1'b1;
+      axi_req_o.w.last                                                     = 1'b1;
     end
   end
 
   // AR Assignment
   if (AxiLite) begin : gen_axi_lite_ar
     always_comb begin : proc_ar_lite_assign
-      axi_req_o.ar       = '0;
-      axi_req_o.ar.addr  = axi_addr_t'(obi_req_i.a.addr);
-      axi_req_o.ar.prot  = axi_obi_prot;
+      axi_req_o.ar      = '0;
+      axi_req_o.ar.addr = axi_addr_t'(obi_req_i.a.addr);
+      axi_req_o.ar.prot = axi_obi_prot;
     end
   end else begin : gen_axi_full_ar
     always_comb begin : proc_ar_assign
@@ -198,8 +189,8 @@ module obi_to_axi #(
   always_comb begin : proc_request_control
     data_offset = '0;
     if (AxiDataWidth > ObiCfg.DataWidth) begin
-      data_offset = obi_req_i.a.addr[$clog2(ObiCfg.DataWidth/8)+:
-                                     $clog2(AxiDataWidth/ObiCfg.DataWidth)];
+      data_offset =
+          obi_req_i.a.addr[$clog2(ObiCfg.DataWidth/8)+:$clog2(AxiDataWidth/ObiCfg.DataWidth)];
     end
     axi_req_o.aw_valid = 1'b0;
     axi_req_o.w_valid  = 1'b0;
@@ -215,44 +206,48 @@ module obi_to_axi #(
       if (!obi_req_i.a.we) begin
         // It is a read request.
         axi_req_o.ar_valid = 1'b1;
-        obi_rsp_o.gnt          = axi_rsp_i.ar_ready;
+        obi_rsp_o.gnt      = axi_rsp_i.ar_ready;
       end else begin
         // Is is a write request, decouple `AW` and `W` channels.
-        unique case ({aw_sent_q, w_sent_q})
-          2'b00 : begin
+        unique case ({
+          aw_sent_q, w_sent_q
+        })
+          2'b00: begin
             // None of the AXI4-Lite writes have been sent jet.
             axi_req_o.aw_valid = 1'b1;
             axi_req_o.w_valid  = 1'b1;
-            unique case ({axi_rsp_i.aw_ready, axi_rsp_i.w_ready})
-              2'b01 : begin // W is sent, still needs AW.
+            unique case ({
+              axi_rsp_i.aw_ready, axi_rsp_i.w_ready
+            })
+              2'b01: begin  // W is sent, still needs AW.
                 w_sent_d = 1'b1;
               end
-              2'b10 : begin // AW is sent, still needs W.
+              2'b10: begin  // AW is sent, still needs W.
                 aw_sent_d = 1'b1;
               end
-              2'b11 : begin // Both are transmitted, grant the write request.
+              2'b11: begin  // Both are transmitted, grant the write request.
                 obi_rsp_o.gnt = 1'b1;
               end
-              default : /* do nothing */;
+              default:  /* do nothing */;
             endcase
           end
-          2'b10 : begin
+          2'b10: begin
             // W has to be sent.
             axi_req_o.w_valid = 1'b1;
             if (axi_rsp_i.w_ready) begin
-              aw_sent_d = 1'b0;
+              aw_sent_d     = 1'b0;
               obi_rsp_o.gnt = 1'b1;
             end
           end
-          2'b01 : begin
+          2'b01: begin
             // AW has to be sent.
             axi_req_o.aw_valid = 1'b1;
             if (axi_rsp_i.aw_ready) begin
-              w_sent_d  = 1'b0;
+              w_sent_d      = 1'b0;
               obi_rsp_o.gnt = 1'b1;
             end
           end
-          default : begin
+          default: begin
             // Failsafe go to IDLE.
             aw_sent_d = 1'b0;
             w_sent_d  = 1'b0;
@@ -269,64 +264,64 @@ module obi_to_axi #(
   logic [1:0] rsp_sel;
 
   fifo_v3 #(
-    .FALL_THROUGH ( 1'b0        ), // No fallthrough for one cycle delay before ready on AXI.
-    .DEPTH        ( MaxRequests ),
-    .dtype        ( logic[1:0]  )
+    .FALL_THROUGH(1'b0),         // No fallthrough for one cycle delay before ready on AXI.
+    .DEPTH       (MaxRequests),
+    .dtype       (logic [1:0])
   ) i_fifo_rsp_mux (
     .clk_i,
     .rst_ni,
-    .flush_i    ( 1'b0             ),
-    .testmode_i ( 1'b0             ),
-    .full_o     ( fifo_full        ),
-    .empty_o    ( fifo_empty       ),
-    .usage_o    ( /*not used*/     ),
-    .data_i     ( {|axi_obi_atop, obi_req_i.a.we} ),
-    .push_i     ( obi_rsp_o.gnt    ),
-    .data_o     ( rsp_sel          ),
-    .pop_i      ( obi_rsp_o.rvalid )
+    .flush_i   (1'b0),
+    .testmode_i(1'b0),
+    .full_o    (fifo_full),
+    .empty_o   (fifo_empty),
+    .usage_o   (  /*not used*/),
+    .data_i    ({|axi_obi_atop, obi_req_i.a.we}),
+    .push_i    (obi_rsp_o.gnt),
+    .data_o    (rsp_sel),
+    .pop_i     (obi_rsp_o.rvalid)
   );
 
   fifo_v3 #(
-    .FALL_THROUGH ( 1'b0        ), // No fallthrough for one cycle delay before ready on AXI.
-    .DEPTH        ( MaxRequests ),
-    .dtype        ( logic[ObiCfg.IdWidth-1:0] )
+    .FALL_THROUGH(1'b0),  // No fallthrough for one cycle delay before ready on AXI.
+    .DEPTH(MaxRequests),
+    .dtype(logic [ObiCfg.IdWidth-1:0])
   ) i_fifo_rid (
     .clk_i,
     .rst_ni,
-    .flush_i    ( 1'b0             ),
-    .testmode_i ( 1'b0             ),
-    .full_o     (),// rsp_mux flow control used
-    .empty_o    (),// rsp_mux flow control used
-    .usage_o    (),// rsp_mux flow control used
-    .data_i     ( obi_req_i.a.aid  ),
-    .push_i     ( obi_rsp_o.gnt    ),// rsp_mux flow control used
-    .data_o     ( obi_rsp_o.r.rid  ),
-    .pop_i      ( obi_rsp_o.rvalid )// rsp_mux flow control used
+    .flush_i   (1'b0),
+    .testmode_i(1'b0),
+    .full_o    (),                 // rsp_mux flow control used
+    .empty_o   (),                 // rsp_mux flow control used
+    .usage_o   (),                 // rsp_mux flow control used
+    .data_i    (obi_req_i.a.aid),
+    .push_i    (obi_rsp_o.gnt),    // rsp_mux flow control used
+    .data_o    (obi_rsp_o.r.rid),
+    .pop_i     (obi_rsp_o.rvalid)  // rsp_mux flow control used
   );
 
-  localparam int unsigned NumObiChans = AxiDataWidth/ObiCfg.DataWidth;
+  localparam int unsigned NumObiChans = AxiDataWidth / ObiCfg.DataWidth;
   localparam int unsigned NumObiChanWidth = $clog2(NumObiChans);
 
-  typedef logic[NumObiChanWidth-1:0] obi_chan_sel_t;
+  typedef logic [NumObiChanWidth-1:0] obi_chan_sel_t;
 
 
   if (AxiDataWidth > ObiCfg.DataWidth) begin : gen_datawidth_offset_fifo
     fifo_v3 #(
-      .FALL_THROUGH ( 1'b0        ), // No fallthrough for one cycle delay before ready on AXI.
-      .DEPTH        ( MaxRequests ),
-      .dtype        ( obi_chan_sel_t  )
+      .FALL_THROUGH(1'b0),           // No fallthrough for one cycle delay before ready on AXI.
+      .DEPTH       (MaxRequests),
+      .dtype       (obi_chan_sel_t)
     ) i_fifo_size (
       .clk_i,
       .rst_ni,
-      .flush_i    ( 1'b0             ),
-      .testmode_i ( 1'b0             ),
-      .full_o     (),// rsp_mux flow control used
-      .empty_o    (),// rsp_mux flow control used
-      .usage_o    (),// rsp_mux flow control used
-      .data_i     ( data_offset      ),
-      .push_i     ( obi_rsp_o.gnt    ),// rsp_mux flow control used
-      .data_o     ( rdata_offset     ),
-      .pop_i      ( obi_rsp_o.rvalid )// rsp_mux flow control used
+      .flush_i   (1'b0),
+      .testmode_i(1'b0),
+      .full_o    (),                 // rsp_mux flow control used
+      .empty_o   (),                 // rsp_mux flow control used
+      .usage_o   (),                 // rsp_mux flow control used
+      .data_i    (data_offset),
+      .push_i    (obi_rsp_o.gnt),    // rsp_mux flow control used
+      .data_o    (rdata_offset),
+      .pop_i     (obi_rsp_o.rvalid)  // rsp_mux flow control used
     );
   end else begin : gen_no_datawidth_offset
     assign rdata_offset = '0;
@@ -354,8 +349,8 @@ module obi_to_axi #(
       (axi_rsp_i.r.resp == axi_pkg::RESP_EXOKAY);
   end
   // User signal concatenation is handled outside
-  assign axi_rsp_b_user_o = axi_rsp_i.b.user;
-  assign axi_rsp_r_user_o = axi_rsp_i.r.user;
+  assign axi_rsp_b_user_o    = axi_rsp_i.b.user;
+  assign axi_rsp_r_user_o    = axi_rsp_i.r.user;
   assign axi_rsp_channel_sel = rsp_sel;
   if (ObiCfg.OptionalCfg.RUserWidth) begin : gen_ruser
     assign obi_rsp_o.r.r_optional.ruser = obi_rsp_user_i;
@@ -367,46 +362,48 @@ module obi_to_axi #(
                            (axi_rsp_i.r_valid & axi_req_o.r_ready);
 
   // pragma translate_off
-  `ifndef SYNTHESIS
-  `ifndef VERILATOR
-    initial begin : proc_assert
-      if (AxiLite) begin
-        assert (ObiCfg.OptionalCfg.UseAtop == 0) else $fatal(1, "ATOP not supported in AXI lite");
-        assert (ObiCfg.OptionalCfg.UseMemtype == 0) else
-          $fatal(1, "Memtype/cache not supported in AXI lite");
-      end
-      assert (ObiCfg.AddrWidth > 32'd0) else $fatal(1, "OBI AddrWidth has to be greater than 0!");
-      assert (AxiAddrWidth > 32'd0) else $fatal(1, "AxiAddrWidth has to be greater than 0!");
-      assert (ObiCfg.DataWidth <= AxiDataWidth && AxiDataWidth % ObiCfg.DataWidth == 0) else
-          $fatal(1, "DataWidth has to be proper divisor of and <= AxiDataWidth!");
-      assert (MaxRequests > 32'd0) else $fatal(1, "MaxRequests has to be greater than 0!");
-      assert (AxiAddrWidth == $bits(axi_req_o.aw.addr)) else
-          $fatal(1, "AxiAddrWidth has to match axi_req_o.aw.addr!");
-      assert (AxiAddrWidth == $bits(axi_req_o.ar.addr)) else
-          $fatal(1, "AxiAddrWidth has to match axi_req_o.ar.addr!");
-      // assert (DataWidth == $bits(axi_req_o.w.data)) else
-      //     $fatal(1, "DataWidth has to match axi_req_o.w.data!");
-      // assert (DataWidth/8 == $bits(axi_req_o.w.strb)) else
-      //     $fatal(1, "DataWidth / 8 has to match axi_req_o.w.strb!");
-      // assert (DataWidth == $bits(axi_rsp_i.r.data)) else
-      //     $fatal(1, "DataWidth has to match axi_rsp_i.r.data!");
+`ifndef SYNTHESIS
+`ifndef VERILATOR
+  initial begin : proc_assert
+    if (AxiLite) begin
+      assert (ObiCfg.OptionalCfg.UseAtop == 0)
+      else $fatal(1, "ATOP not supported in AXI lite");
+      assert (ObiCfg.OptionalCfg.UseMemtype == 0)
+      else $fatal(1, "Memtype/cache not supported in AXI lite");
     end
-    default disable iff (~rst_ni);
-    assert property (@(posedge clk_i) (obi_req_i.req && !obi_rsp_o.gnt) |=> obi_req_i.req) else
-        $fatal(1, "It is not allowed to deassert the request if it was not granted!");
-    assert property (@(posedge clk_i) (obi_req_i.req && !obi_rsp_o.gnt) |=>
-                                       $stable(obi_req_i.a.addr)) else
-        $fatal(1, "obi_req_i.a.addr has to be stable if request is not granted!");
-    assert property (@(posedge clk_i) (obi_req_i.req && !obi_rsp_o.gnt) |=>
-                                       $stable(obi_req_i.a.we)) else
-        $fatal(1, "obi_req_i.a.we has to be stable if request is not granted!");
-    assert property (@(posedge clk_i) (obi_req_i.req && !obi_rsp_o.gnt) |=>
-                                       $stable(obi_req_i.a.wdata)) else
-        $fatal(1, "obi_req_i.a.wdata has to be stable if request is not granted!");
-    assert property (@(posedge clk_i) (obi_req_i.req && !obi_rsp_o.gnt) |=>
-                                       $stable(obi_req_i.a.be)) else
-        $fatal(1, "obi_req_i.a.be has to be stable if request is not granted!");
-  `endif
-  `endif
+    assert (ObiCfg.AddrWidth > 32'd0)
+    else $fatal(1, "OBI AddrWidth has to be greater than 0!");
+    assert (AxiAddrWidth > 32'd0)
+    else $fatal(1, "AxiAddrWidth has to be greater than 0!");
+    assert (ObiCfg.DataWidth <= AxiDataWidth && AxiDataWidth % ObiCfg.DataWidth == 0)
+    else $fatal(1, "DataWidth has to be proper divisor of and <= AxiDataWidth!");
+    assert (MaxRequests > 32'd0)
+    else $fatal(1, "MaxRequests has to be greater than 0!");
+    assert (AxiAddrWidth == $bits(axi_req_o.aw.addr))
+    else $fatal(1, "AxiAddrWidth has to match axi_req_o.aw.addr!");
+    assert (AxiAddrWidth == $bits(axi_req_o.ar.addr))
+    else $fatal(1, "AxiAddrWidth has to match axi_req_o.ar.addr!");
+    // assert (DataWidth == $bits(axi_req_o.w.data)) else
+    //     $fatal(1, "DataWidth has to match axi_req_o.w.data!");
+    // assert (DataWidth/8 == $bits(axi_req_o.w.strb)) else
+    //     $fatal(1, "DataWidth / 8 has to match axi_req_o.w.strb!");
+    // assert (DataWidth == $bits(axi_rsp_i.r.data)) else
+    //     $fatal(1, "DataWidth has to match axi_rsp_i.r.data!");
+  end
+  default disable iff (~rst_ni);
+  assert property (@(posedge clk_i) (obi_req_i.req && !obi_rsp_o.gnt) |=> obi_req_i.req)
+  else $fatal(1, "It is not allowed to deassert the request if it was not granted!");
+  assert property (@(posedge clk_i) (obi_req_i.req && !obi_rsp_o.gnt) |=> $stable(obi_req_i.a.addr))
+  else $fatal(1, "obi_req_i.a.addr has to be stable if request is not granted!");
+  assert property (@(posedge clk_i) (obi_req_i.req && !obi_rsp_o.gnt) |=> $stable(obi_req_i.a.we))
+  else $fatal(1, "obi_req_i.a.we has to be stable if request is not granted!");
+  assert property (@(posedge clk_i) (obi_req_i.req && !obi_rsp_o.gnt) |=> $stable(
+      obi_req_i.a.wdata
+  ))
+  else $fatal(1, "obi_req_i.a.wdata has to be stable if request is not granted!");
+  assert property (@(posedge clk_i) (obi_req_i.req && !obi_rsp_o.gnt) |=> $stable(obi_req_i.a.be))
+  else $fatal(1, "obi_req_i.a.be has to be stable if request is not granted!");
+`endif
+`endif
   // pragma translate_on
 endmodule

--- a/hw/mem_tile.sv
+++ b/hw/mem_tile.sv
@@ -6,6 +6,7 @@
 
 `include "common_cells/registers.svh"
 `include "axi/typedef.svh"
+`include "obi/typedef.svh"
 
 module mem_tile
   import floo_pkg::*;
@@ -15,7 +16,10 @@ module mem_tile
   // The maximum data width of the instantiated SRAMs
   parameter int unsigned SramDataWidth = 256,  // in bits
   // The number of words in the instantiated SRAMs
-  parameter int unsigned SramNumWords  = 512   // in #words
+  parameter int unsigned SramNumWords = 512, // in #words
+  parameter bit          AxiUserAtop      = 1'b1,
+  parameter int unsigned AxiUserAtopMsb   = 3,
+  parameter int unsigned AxiUserAtopLsb   = 0
 ) (
   input  logic                    clk_i,
   input  logic                    rst_ni,
@@ -185,65 +189,264 @@ module mem_tile
     .axi_rsp_i       (axi_rsp)
   );
 
+//  ///////////////////////
+//  // axi2mem converter //
+//  ///////////////////////
+
+//  typedef logic [$clog2(MemTileSize)-1:0] mem_addr_t;
+//  typedef logic [SramDataWidth-1:0] mem_data_t;
+//  typedef logic [SramDataWidth/8-1:0] mem_be_t;
+
+//  logic [NumBanksPerWord-1:0] mem_req, mem_req_q;
+//  logic [NumBanksPerWord-1:0] mem_we;
+//  mem_addr_t [NumBanksPerWord-1:0] mem_addr;
+//  mem_data_t [NumBanksPerWord-1:0] mem_wdata;
+//  mem_be_t [NumBanksPerWord-1:0] mem_be;
+//  mem_data_t [NumBanksPerWord-1:0] mem_rdata;
+
+//  axi_to_mem #(
+//    .AddrWidth  ( $clog2(MemTileSize)   ),
+//    .DataWidth  ( AxiCfgJoin.DataWidth  ),
+//    .IdWidth    ( AxiCfgJoin.OutIdWidth ),
+//    .NumBanks   ( NumBanksPerWord   ),
+//    .axi_req_t  ( axi_nw_join_req_t ),
+//    .axi_resp_t ( axi_nw_join_rsp_t )
+//  ) i_axi_to_mem (
+//    .clk_i,
+//    .rst_ni,
+//    .busy_o       ( ),
+//    .axi_req_i    ( axi_req ),
+//    .axi_resp_o   ( axi_rsp ),
+//    .mem_req_o    ( mem_req ),
+//    .mem_gnt_i    ( {NumBanksPerWord{1'b1}} ),
+//    .mem_addr_o   ( mem_addr  ),
+//    .mem_wdata_o  ( mem_wdata ),
+//    .mem_strb_o   ( mem_be    ),
+//    .mem_atop_o   ( ), // No atops on wide
+//    .mem_we_o     ( mem_we    ),
+//    .mem_rvalid_i ( mem_req_q ),
+//    .mem_rdata_i  ( mem_rdata )
+//  );
+//  `FF(mem_req_q, mem_req, '0)
+
   ///////////////////////
-  // axi2mem converter //
+  // axi2obi converter //
   ///////////////////////
 
-  typedef logic [$clog2(MemTileSize)-1:0] mem_addr_t;
-  typedef logic [SramDataWidth-1:0] mem_data_t;
-  typedef logic [SramDataWidth/8-1:0] mem_be_t;
+  // typedef obi for atomic config
+  localparam obi_pkg::obi_optional_cfg_t MgrObiOptionalCfg= '{
+    UseAtop:    1'b1,
+    UseMemtype: 1'b0,
+    UseProt:    1'b0,
+    UseDbg:     1'b0,
+    AUserWidth:    0,
+    WUserWidth:    0,
+    RUserWidth:    0,
+    MidWidth:      0,
+    AChkWidth:     0,
+    RChkWidth:     0
+  };
+  localparam obi_pkg::obi_cfg_t MgrObiCfg =
+            obi_pkg::obi_default_cfg(AxiCfgJoin.AddrWidth,
+                                     AxiCfgJoin.DataWidth,
+                                     (AxiUserAtop ? AxiUserAtopMsb+1-AxiUserAtopLsb : AxiCfgJoin.OutIdWidth),
+                                     MgrObiOptionalCfg);
+  `OBI_TYPEDEF_ATOP_A_OPTIONAL(mgr_obi_a_optional_t)
+  `OBI_TYPEDEF_A_CHAN_T(mgr_obi_a_chan_t,
+                        MgrObiCfg.AddrWidth,
+                        MgrObiCfg.DataWidth,
+                        MgrObiCfg.IdWidth,
+                        mgr_obi_a_optional_t)
+  `OBI_TYPEDEF_DEFAULT_REQ_T(mgr_obi_req_t, mgr_obi_a_chan_t)
+  typedef struct packed { 
+  	logic exokay; 
+  } mgr_obi_r_optional_t;
+  `OBI_TYPEDEF_R_CHAN_T(mgr_obi_r_chan_t, MgrObiCfg.DataWidth, MgrObiCfg.IdWidth, mgr_obi_r_optional_t)
+  `OBI_TYPEDEF_RSP_T(mgr_obi_rsp_t, mgr_obi_r_chan_t)
 
-  logic [NumBanksPerWord-1:0] mem_req, mem_req_q;
-  logic      [NumBanksPerWord-1:0] mem_we;
-  mem_addr_t [NumBanksPerWord-1:0] mem_addr;
-  mem_data_t [NumBanksPerWord-1:0] mem_wdata;
-  mem_be_t   [NumBanksPerWord-1:0] mem_be;
-  mem_data_t [NumBanksPerWord-1:0] mem_rdata;
 
-  axi_to_mem #(
-    .AddrWidth ($clog2(MemTileSize)),
-    .DataWidth (AxiCfgJoin.DataWidth),
-    .IdWidth   (AxiCfgJoin.OutIdWidth),
-    .NumBanks  (NumBanksPerWord),
-    .axi_req_t (axi_nw_join_req_t),
-    .axi_resp_t(axi_nw_join_rsp_t)
-  ) i_axi_to_mem (
+  // typedef obi for default config
+  localparam obi_pkg::obi_optional_cfg_t SbrObiOptionalCfg= '{
+    UseAtop:    1'b0,
+    UseMemtype: 1'b0,
+    UseProt:    1'b0,
+    UseDbg:     1'b0,
+    AUserWidth:    0,
+    WUserWidth:    0,
+    RUserWidth:    0,
+    MidWidth:      0,
+    AChkWidth:     0,
+    RChkWidth:     0
+  };
+  localparam obi_pkg::obi_cfg_t SbrObiCfg = 
+  	obi_pkg::obi_default_cfg(AxiCfgJoin.AddrWidth,
+														AxiCfgJoin.DataWidth,
+                            AxiCfgJoin.OutIdWidth,
+                            SbrObiOptionalCfg);
+  `OBI_TYPEDEF_MINIMAL_A_OPTIONAL(sbr_obi_a_optional_t)
+  `OBI_TYPEDEF_A_CHAN_T(sbr_obi_a_chan_t,
+                        SbrObiCfg.AddrWidth,
+                        SbrObiCfg.DataWidth,
+                        SbrObiCfg.IdWidth,
+                        sbr_obi_a_optional_t)
+  `OBI_TYPEDEF_DEFAULT_REQ_T(sbr_obi_req_t, sbr_obi_a_chan_t)
+  `OBI_TYPEDEF_MINIMAL_R_OPTIONAL(sbr_obi_r_optional_t)
+  `OBI_TYPEDEF_R_CHAN_T(sbr_obi_r_chan_t, SbrObiCfg.DataWidth, SbrObiCfg.IdWidth, sbr_obi_r_optional_t)
+  `OBI_TYPEDEF_RSP_T(sbr_obi_rsp_t, sbr_obi_r_chan_t)
+
+
+  logic [AxiCfgJoin.OutIdWidth-1:0] axi_in_aw_id, axi_in_ar_id;
+  logic [AxiCfgJoin.UserWidth-1:0] axi_in_aw_user, axi_in_w_user, axi_in_ar_user;
+  logic [MgrObiCfg.IdWidth-1:0] obi_in_write_aid, obi_in_read_aid;
+
+  logic [AxiCfgJoin.UserWidth-1:0] axi_in_rsp_aw_user, axi_in_rsp_w_user, axi_in_rsp_ar_user;
+  logic [AxiCfgJoin.UserWidth-1:0] axi_in_r_user, axi_in_b_user;
+  logic axi_in_rsp_write_bank_strobe, axi_in_rsp_read_size_enable;
+
+  logic [MgrObiCfg.IdWidth-1:0] obi_in_rsp_write_rid, obi_in_rsp_read_rid;
+
+  mgr_obi_req_t obi_req;
+  mgr_obi_rsp_t obi_rsp;
+  sbr_obi_req_t mem_obi_req;
+  sbr_obi_rsp_t mem_obi_rsp;
+
+  if (AxiUserAtop) begin : gen_user_atop
+    assign obi_in_write_aid = axi_in_aw_user[AxiUserAtopMsb-1:AxiUserAtopLsb];
+    assign obi_in_read_aid = axi_in_ar_user[AxiUserAtopMsb-1:AxiUserAtopLsb];
+  end else begin : gen_plain_atop
+    assign obi_in_write_aid = axi_in_aw_id;
+    assign obi_in_read_aid = axi_in_ar_id;
+  end                                                      
+
+  always_comb begin : proc_obi_user
+    axi_in_r_user = '0;
+    axi_in_b_user = '0;
+    // Respond with same ATOP ID
+    if (AxiUserAtop) begin
+      axi_in_r_user[AxiUserAtopMsb-1:AxiUserAtopLsb] |= axi_in_rsp_read_size_enable ? obi_in_rsp_read_rid : '0;
+      // No need to buffer the ATOP ID
+      axi_in_b_user[AxiUserAtopMsb-1:AxiUserAtopLsb] |= axi_in_rsp_write_bank_strobe ? obi_in_rsp_write_rid : '0;
+    end
+  end
+
+  axi_to_obi #(
+    .ObiCfg       ( MgrObiCfg             ),
+    .obi_req_t 	  ( mgr_obi_req_t         ),
+    .obi_rsp_t 	  ( mgr_obi_rsp_t         ),
+    .obi_a_chan_t ( mgr_obi_a_chan_t      ),
+    .obi_r_chan_t ( mgr_obi_r_chan_t      ),
+    .AxiAddrWidth ( $clog2(MemTileSize)   ),
+    .AxiDataWidth ( AxiCfgJoin.DataWidth  ),
+    .AxiIdWidth	  ( AxiCfgJoin.OutIdWidth ),
+    .AxiUserWidth ( AxiCfgJoin.UserWidth  ),
+    .MaxTrans     ( 2                     ),
+    .axi_req_t    ( axi_nw_join_req_t 	  ),
+    .axi_rsp_t    ( axi_nw_join_rsp_t 	  )
+  ) i_axi_to_obi (
     .clk_i,
     .rst_ni,
-    .busy_o      (),
-    .axi_req_i   (axi_req),
-    .axi_resp_o  (axi_rsp),
-    .mem_req_o   (mem_req),
-    .mem_gnt_i   ({NumBanksPerWord{1'b1}}),
-    .mem_addr_o  (mem_addr),
-    .mem_wdata_o (mem_wdata),
-    .mem_strb_o  (mem_be),
-    .mem_atop_o  (),                         // No atops on wide
-    .mem_we_o    (mem_we),
-    .mem_rvalid_i(mem_req_q),
-    .mem_rdata_i (mem_rdata)
-  );
+    .testmode_i        ( test_enable_i    ),
+    .axi_req_i         ( axi_req          ),
+    .axi_rsp_o         ( axi_rsp          ),
+    .obi_req_o         ( obi_req          ),
+    .obi_rsp_i         ( obi_rsp          ),
 
-  `FF(mem_req_q, mem_req, '0)
+		.req_aw_id_o       ( axi_in_aw_id       ),
+		.req_aw_user_o     ( axi_in_aw_user     ),
+		.req_w_user_o      ( axi_in_w_user      ),
+		.req_write_aid_i   ( obi_in_write_aid   ),
+		.req_write_auser_i ( '0                 ),
+		.req_write_wuser_i ( '0                 ),
+
+    .req_ar_id_o      ( axi_in_ar_id      ),
+    .req_ar_user_o    ( axi_in_ar_user    ),
+    .req_read_aid_i   ( obi_in_read_aid   ),
+    .req_read_auser_i ( '0                ),
+
+    .rsp_write_aw_user_o   ( axi_in_rsp_aw_user           ),
+    .rsp_write_w_user_o    ( axi_in_rsp_w_user            ),
+    .rsp_write_bank_strb_o ( axi_in_rsp_write_bank_strobe ),
+    .rsp_write_rid_o       ( obi_in_rsp_write_rid         ),
+    .rsp_write_ruser_o     ( /* Unused */                 ),
+    .rsp_write_last_o      ( /* Unused */                 ),
+    .rsp_write_hs_o        ( /* Unused */                 ),
+    .rsp_b_user_i          ( axi_in_b_user                ),
+
+    .rsp_read_ar_user_o    ( /* Unused */                 ),
+    .rsp_read_size_enable_o( axi_in_rsp_read_size_enable  ),
+    .rsp_read_rid_o        ( obi_in_rsp_read_rid          ),
+    .rsp_read_ruser_o      ( /* Unused */                 ),
+    .rsp_r_user_i          ( axi_in_r_user                )
+  );
 
   /////////////////
   // SRAM macros //
   /////////////////
 
+  logic mem_req;
+  logic mem_we;
+  logic [AxiCfgJoin.AddrWidth-1:0] mem_addr;
+  logic [AxiCfgW.DataWidth-1:0] mem_wdata;
+  logic [AxiCfgW.DataWidth/8-1:0] mem_be;
+  logic [AxiCfgW.DataWidth-1:0] mem_rdata;
+
+  obi_atop_resolver #(
+    .SbrPortObiCfg            (MgrObiCfg),
+    .MgrPortObiCfg            (SbrObiCfg),
+    .sbr_port_obi_req_t       (mgr_obi_req_t),
+    .sbr_port_obi_rsp_t       (mgr_obi_rsp_t),
+    .mgr_port_obi_req_t       (sbr_obi_req_t),
+    .mgr_port_obi_rsp_t       (sbr_obi_rsp_t),
+    .mgr_port_obi_a_optional_t(mgr_obi_a_optional_t),
+    .mgr_port_obi_r_optional_t(mgr_obi_r_optional_t),
+    .LrScEnable               (1'b1),
+    .RegisterAmo              (1'b0),
+    .RiscvWordWidth           (32)
+  ) i_obi_atop_resolver (
+    .clk_i,
+    .rst_ni,
+    .testmode_i     ( test_enable_i ),
+    .sbr_port_req_i ( obi_req       ),
+    .sbr_port_rsp_o ( obi_rsp       ),
+    .mgr_port_req_o ( mem_obi_req   ),
+    .mgr_port_rsp_i ( mem_obi_rsp   )
+  );
+
+  obi_sram_shim #(
+    .ObiCfg    ( SbrObiCfg     ),
+    .obi_req_t ( sbr_obi_req_t ),
+    .obi_rsp_t ( sbr_obi_rsp_t )
+  ) i_sram_shim_bank (
+    .clk_i,
+    .rst_ni,
+    .obi_req_i ( mem_obi_req  ),
+    .obi_rsp_o ( mem_obi_rsp  ),
+    .req_o     ( mem_req      ),
+    .we_o      ( mem_we       ),
+    .addr_o    ( mem_addr     ),
+    .wdata_o   ( mem_wdata    ),
+    .be_o      ( mem_be       ),
+    .gnt_i     ( 1'b1         ),
+    .rdata_i   ( mem_rdata    )
+  );
+
   logic [NumBanksPerWord-1:0][SramMacroSelWidth-1:0] sram_macro_sel, sram_macro_sel_q;
-  logic      [NumBanksPerWord-1:0][  SramAddrWidth-1:0] sram_addr;
-  mem_data_t [    NumBankRows-1:0][NumBanksPerWord-1:0] mem_rdata_split;
+  logic [NumBanksPerWord-1:0][SramAddrWidth-1:0] sram_addr;
+  logic [NumBankRows-1:0][NumBanksPerWord-1:0][SramDataWidth-1:0] sram_rdata_split;
+
+  logic [NumBanksPerWord-1:0][SramDataWidth-1:0] sram_wdata;
+  logic [NumBanksPerWord-1:0][SramDataWidth/8-1:0] sram_be;
 
   for (genvar i = 0; i < NumBanksPerWord; i++) begin : gen_addresses
     // Calculate the addresses
-    assign sram_addr[i]      = mem_addr[i][SramAddrWidthOffset+:SramAddrWidth];
-    assign sram_macro_sel[i] = mem_addr[i][SramMacroSelOffset+:SramMacroSelWidth];
-
+    assign sram_addr[i] = mem_addr[SramAddrWidthOffset +: SramAddrWidth];
+    assign sram_macro_sel[i] = mem_addr[SramMacroSelOffset +: SramMacroSelWidth];
     // Register the macro selection to select the correct macro for the next cycle
-    `FFL(sram_macro_sel_q[i], sram_macro_sel[i], mem_req[i] & ~mem_we[i], '0)
-
-    // Return the read data from the previously selected macro
-    assign mem_rdata[i] = mem_rdata_split[sram_macro_sel_q[i]][i];
+    `FFL(sram_macro_sel_q[i], sram_macro_sel[i], mem_req & ~mem_we, '0);
+    // Assign the data
+    assign sram_wdata[i] = mem_wdata[i*SramDataWidth +: SramDataWidth];
+    assign sram_be[i] = mem_be[i*SramDataWidth/8 +: SramDataWidth/8];
+    assign mem_rdata[i*SramDataWidth +: SramDataWidth] = sram_rdata_split[sram_macro_sel_q[i]][i];
   end
 
   for (genvar i = 0; i < NumBanksPerWord; i++) begin : gen_sram_banks
@@ -256,12 +459,12 @@ module mem_tile
       ) i_mem (
         .clk_i,
         .rst_ni,
-        .req_i  (mem_req[i] && (sram_macro_sel[i] == j)),
-        .we_i   (mem_we[i] && (sram_macro_sel[i] == j)),
-        .addr_i (sram_addr[i]),
-        .wdata_i(mem_wdata[i]),
-        .be_i   (mem_be[i]),
-        .rdata_o(mem_rdata_split[j][i])
+        .req_i   ( mem_req && (sram_macro_sel[i] == j) ),
+        .we_i    ( mem_we && (sram_macro_sel[i] == j)  ),
+        .addr_i  ( sram_addr[i]                        ),
+        .wdata_i ( sram_wdata[i]                       ),
+        .be_i    ( sram_be[i]                          ),
+        .rdata_o ( sram_rdata_split[j][i]              )
       );
     end
   end

--- a/sw/snitch/tests/multicluster_atomics.c
+++ b/sw/snitch/tests/multicluster_atomics.c
@@ -1,0 +1,115 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+/* Tests that a single core can do atomics */
+
+#include <snrt.h>
+
+//===============================================================
+// RISC-V atomic instruction wrappers
+//===============================================================
+
+static inline uint32_t lr_w(volatile uint32_t* addr) {
+    uint32_t data = 0;
+    asm volatile("lr.w %[data], (%[addr])"
+                 : [ data ] "+r"(data)
+                 : [ addr ] "r"(addr)
+                 : "memory");
+    return data;
+}
+
+static inline uint32_t sc_w(volatile uint32_t* addr, uint32_t data) {
+    uint32_t err = 0;
+    asm volatile("sc.w %[err], %[data], (%[addr])"
+                 : [ err ] "+r"(err)
+                 : [ addr ] "r"(addr), [ data ] "r"(data)
+                 : "memory");
+    return err;
+}
+
+static inline uint32_t atomic_maxu_fetch(volatile uint32_t* addr,
+                                         uint32_t data) {
+    uint32_t prev = 0;
+    asm volatile("amomaxu.w %[prev], %[data], (%[addr])"
+                 : [ prev ] "+r"(prev)
+                 : [ addr ] "r"(addr), [ data ] "r"(data)
+                 : "memory");
+    return prev;
+}
+
+static inline uint32_t atomic_minu_fetch(volatile uint32_t* addr,
+                                         uint32_t data) {
+    uint32_t prev = 0;
+    asm volatile("amominu.w %[prev], %[data], (%[addr])"
+                 : [ prev ] "+r"(prev)
+                 : [ addr ] "r"(addr), [ data ] "r"(data)
+                 : "memory");
+    return prev;
+}
+
+//===============================================================
+// Test atomics on a given memory location (single core)
+//===============================================================
+
+uint32_t test_atomics(volatile uint32_t* atomic_var) {
+    uint32_t tmp = 0;
+    uint32_t nerrors = 0;
+    uint32_t dummy_val = 42;
+    uint32_t amo_operand;
+    uint32_t expected_val;
+
+    uint32_t cluster_num = snrt_cluster_num();
+
+    /******************************************************
+     * Initialize
+     ******************************************************/
+    *atomic_var = 0;
+    expected_val = *atomic_var;
+    snrt_inter_cluster_barrier();
+
+    /******************************************************
+     * Test 2: AMOADD
+     ******************************************************/
+    amo_operand = 1;
+    __atomic_add_fetch(atomic_var, amo_operand, __ATOMIC_RELAXED);
+    snrt_inter_cluster_barrier();
+    expected_val += amo_operand * cluster_num;
+    if (*atomic_var != expected_val) nerrors++;
+    snrt_inter_cluster_barrier();
+
+    /******************************************************
+     * Test 3: AMOSUB
+     ******************************************************/
+    amo_operand = 1;
+    __atomic_sub_fetch(atomic_var, amo_operand, __ATOMIC_RELAXED);
+    snrt_inter_cluster_barrier();
+    expected_val -= amo_operand * cluster_num;
+    if (*atomic_var != expected_val) nerrors++;
+    snrt_inter_cluster_barrier();
+
+    return nerrors;
+}
+
+// Use at least two locations to test unaligned accesses
+#define NUM_SPM_LOCATIONS 2
+volatile uint32_t l3_a[NUM_SPM_LOCATIONS];
+volatile uint32_t* multicluster_error;
+
+int main() {
+    uint32_t core_id = snrt_cluster_core_idx();
+    uint32_t core_num = snrt_cluster_core_num();
+    uint32_t register volatile nerrors = 0;
+
+    if (core_id == 0) {
+    	// Verify atomics
+        for (uint32_t i = 0; i < NUM_SPM_LOCATIONS; i++) {
+            nerrors = test_atomics(&l3_a[i]);
+            __atomic_add_fetch(multicluster_error, nerrors, __ATOMIC_RELAXED);
+            snrt_inter_cluster_barrier();
+            return *multicluster_error;
+        }
+    } else {
+        return 0;
+    }
+}

--- a/sw/sw.mk
+++ b/sw/sw.mk
@@ -25,7 +25,7 @@ SNRT_INCDIRS        = $(PB_INCDIR)
 SNRT_BUILD_APPS     = OFF
 SNRT_MEMORY_LD      = $(PB_SNITCH_SW_DIR)/memory.ld
 
-ifneq (,$(filter chs-bootrom% chs-sw% sn% pb-snrt-tests% sw%,$(MAKECMDGOALS)))
+ifneq (,$(filter chs-bootrom% chs-sw% sn% pb-sn-tests% sw%,$(MAKECMDGOALS)))
 include $(SN_ROOT)/target/snitch_cluster/sw.mk
 endif
 
@@ -38,9 +38,9 @@ PB_SNRT_TEST_DUMP = $(abspath $(addprefix $(PB_SNRT_TESTS_BUILDDIR)/,$(addsuffix
 
 .PHONY: pb-snrt-tests clean-pb-snrt-tests
 
-pb-snrt-tests: $(PB_SNRT_TEST_ELFS) $(PB_SNRT_TEST_DUMP)
+pb-sn-tests: $(PB_SNRT_TEST_ELFS) $(PB_SNRT_TEST_DUMP)
 
-clean-pb-snrt-tests:
+clean-pb-sn-tests:
 	rm -rf $(PB_SNRT_TEST_ELFS)
 
 $(PB_SNRT_TESTS_BUILDDIR)/%.d: $(PB_SNRT_TESTS_DIR)/%.c | $(PB_SNRT_TESTS_BUILDDIR)
@@ -97,6 +97,6 @@ chs-sw-tests-clean:
 sn-tests-clean: sn-clean-tests
 
 .PHONY: sw sw-tests sw-clean sw-tests-clean
-sw sw-tests: chs-sw-tests sn-tests pb-snrt-tests
+sw sw-tests: chs-sw-tests sn-tests pb-sn-tests
 
-sw-clean sw-tests-clean: chs-sw-tests-clean sn-tests-clean clean-pb-snrt-tests
+sw-clean sw-tests-clean: chs-sw-tests-clean sn-tests-clean clean-pb-sn-tests


### PR DESCRIPTION
This PR modifies the memory tile to replace the AXI to L2 memory interconnect with an AXI to OBI conversion module and an OBI to L2 memory interconnect. The OBI atomic adapter is modified to handle wide OBI transfers containing a 32b atomic transfer.