### PR TITLE
ci: Cache `.cache/pip` instead of `.venv`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,6 +21,9 @@ init-deps:
     - .init-deps-tpl
   script:
     - ':'
+  artifacts:
+    paths:
+      - pd/ci.yml
 
 ########################
 # Build Software Tests #
@@ -98,22 +101,12 @@ sim-vsim:
 # Physical Design #
 ###################
 
-init-pd:
-  stage: init
-  extends:
-    - .cache-deps
-    - .init-env
-  script: make init-pd
-  artifacts:
-    paths:
-      - pd/ci.yml
-
 subpipe:
   stage: build
   needs:
-    - init-pd
+    - init-deps
   trigger:
     include:
       - artifact: pd/ci.yml
-        job: init-pd
+        job: init-deps
     strategy: depend

--- a/.gitlab/common.yml
+++ b/.gitlab/common.yml
@@ -2,22 +2,27 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+variables:
+  PIP_CACHE_DIR: "$CI_PROJECT_DIR/.cache/pip"
+
 # Sources the environment variables for the IIS environment
 .init-env:
   before_script:
     source iis-env.sh
 
-# Check the cache for bender dependencies
+# Check the cache for bender and python dependencies
 .cache-deps:
-  cache:
+  cache: &global_cache
     key:
       files:
         - Bender.lock
+        - requirements.txt
     paths:
       - .bender
+      - .cache/pip
     policy: pull
 
-# Update the cache with the bender dependencies
+# Update the cache with bender and python dependencies
 .init-deps-tpl:
   before_script:
     # Collect bender sourcess
@@ -27,11 +32,8 @@
     # Pull the PD repository
     - make init-pd
   cache:
-    key:
-      files:
-        - Bender.lock
-    paths:
-      - .bender
+    # inherit all global cache settings
+    <<: *global_cache
     policy: pull-push
 
 # Generate the RTL sources

--- a/.gitlab/common.yml
+++ b/.gitlab/common.yml
@@ -7,19 +7,17 @@
   before_script:
     source iis-env.sh
 
-# Check the cache for bender and python dependencies
+# Check the cache for bender dependencies
 .cache-deps:
   cache:
     key:
       files:
         - Bender.lock
-        - requirements.txt
     paths:
       - .bender
-      - .venv
     policy: pull
 
-# Update the cache with the bender and python dependencies
+# Update the cache with the bender dependencies
 .init-deps-tpl:
   before_script:
     # Collect bender sourcess
@@ -32,10 +30,8 @@
     key:
       files:
         - Bender.lock
-        - requirements.txt
     paths:
       - .bender
-      - .venv
     policy: pull-push
 
 # Generate the RTL sources

--- a/Makefile
+++ b/Makefile
@@ -166,8 +166,8 @@ python-venv: .venv
 	$(BASE_PYTHON) -m venv $@
 	. $@/bin/activate && \
 	python -m pip install --upgrade pip setuptools && \
-	python -m pip install -r requirements.txt && \
-	python -m pip install $(shell $(BENDER) path floo_noc) --no-deps
+	python -m pip install --cache-dir $(PIP_CACHE_DIR) -r requirements.txt && \
+	python -m pip install --cache-dir $(PIP_CACHE_DIR) $(shell $(BENDER) path floo_noc) --no-deps
 
 python-venv-clean:
 	rm -rf .venv

--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,7 @@ include $(PB_ROOT)/target/sim/traces.mk
 ########
 
 BASE_PYTHON ?= python
+PIP_CACHE_DIR ?= $(PB_ROOT)/.cache/pip
 
 .PHONY: dvt-flist python-venv python-venv-clean verible-fmt
 


### PR DESCRIPTION
* Merges `init-deps` and `init-pd` CI jobs, which essentially did the same thing.
* Caching the entire virtual environment causes some spurious issues in the CI. Instead, only the pip packages are now cached, similar as in the snitch cluster.