### PR TITLE
hw: Update macro cuts in `mem_tile`

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -213,7 +213,7 @@ packages:
     - common_cells
     - register_interface
   obi:
-    revision: ad1d48f025be540344960ea83b4bff39876f9b36
+    revision: 95f023208ecaa516860e66a1701a93912ffc62a2
     version: null
     source:
       Git: https://github.com/pulp-platform/obi.git

--- a/Bender.yml
+++ b/Bender.yml
@@ -14,7 +14,7 @@ dependencies:
   cheshire: { git: "https://github.com/pulp-platform/cheshire.git", rev: "picobello" }
   snitch_cluster:  { git: "https://github.com/pulp-platform/snitch_cluster.git", rev: "develop" }
   floo_noc: { git: "https://github.com/pulp-platform/FlooNoC.git", rev: "fischeti/new-mcast"}
-  obi: { git: "https://github.com/pulp-platform/obi.git", rev: "ad1d48f025be540344960ea83b4bff39876f9b36"}
+  obi: { git: "https://github.com/pulp-platform/obi.git", rev: "95f023208ecaa516860e66a1701a93912ffc62a2"}
   axi_obi: { path: "hw/axi_obi" }
   picobello-pd:  { path: "./pd" }
   fhg_spu_cluster:  { path: "./.deps/fhg_spu_cluster" }

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ floo-clean:
 ###################
 
 PD_REMOTE ?= git@iis-git.ee.ethz.ch:picobello/picobello-pd.git
-PD_COMMIT ?= 1f60bc7569ec29e05ba996f7d7664476ac6771e2
+PD_COMMIT ?= f00937b43b8b0e5568adced59c833787e1c99efb
 PD_DIR = $(PB_ROOT)/pd
 SPU_REMOTE ?= git@iis-git.ee.ethz.ch:picobello/fhg_spu_cluster.git
 SPU_COMMIT ?= 7c50fc53b895dba4a14575435c49d289963ecfb4

--- a/hw/axi_obi/Bender.yml
+++ b/hw/axi_obi/Bender.yml
@@ -9,7 +9,7 @@ package:
 
 dependencies:
   axi:          { git: "https://github.com/pulp-platform/axi.git",          version: 0.39.1 }
-  obi:          { git: "https://github.com/pulp-platform/obi.git",rev: "ad1d48f025be540344960ea83b4bff39876f9b36"}
+  obi:          { git: "https://github.com/pulp-platform/obi.git", rev: "95f023208ecaa516860e66a1701a93912ffc62a2"}
   common_cells: { git: "https://github.com/pulp-platform/common_cells.git", version: 1.31.1 }
 
 sources:

--- a/hw/mem_tile.sv
+++ b/hw/mem_tile.sv
@@ -15,9 +15,9 @@ module mem_tile
   import obi_pkg::*;
 #(
   // The maximum data width of the instantiated SRAMs
-  parameter int unsigned SramDataWidth  = 256,   // in bits
+  parameter int unsigned SramDataWidth  = 128,   // in bits
   // The number of words in the instantiated SRAMs
-  parameter int unsigned SramNumWords   = 512,   // in #words
+  parameter int unsigned SramNumWords   = 1024,  // in #words
   parameter bit          AxiUserAtop    = 1'b1,
   parameter int unsigned AxiUserAtopMsb = 3,
   parameter int unsigned AxiUserAtopLsb = 0

--- a/hw/mem_tile.sv
+++ b/hw/mem_tile.sv
@@ -358,10 +358,10 @@ module mem_tile
     .sbr_port_obi_rsp_t       (mgr_obi_rsp_t),
     .mgr_port_obi_req_t       (sbr_obi_req_t),
     .mgr_port_obi_rsp_t       (sbr_obi_rsp_t),
-    .mgr_port_obi_a_optional_t(mgr_obi_a_optional_t),
-    .mgr_port_obi_r_optional_t(mgr_obi_r_optional_t),
+    .mgr_port_obi_a_optional_t(sbr_obi_a_optional_t),
+    .mgr_port_obi_r_optional_t(sbr_obi_r_optional_t),
     .LrScEnable               (1'b1),
-    .RegisterAmo              (1'b0),
+    .RegisterAmo              (1'b1),
     .RiscvWordWidth           (32)
   ) i_obi_atop_resolver (
     .clk_i,

--- a/sw/snitch/tests/multicluster_atomics.c
+++ b/sw/snitch/tests/multicluster_atomics.c
@@ -72,9 +72,9 @@ uint32_t test_atomics(volatile uint32_t* atomic_var) {
      * Test 2: AMOADD
      ******************************************************/
     amo_operand = 1;
+    expected_val += amo_operand * cluster_num;
     __atomic_add_fetch(atomic_var, amo_operand, __ATOMIC_RELAXED);
     snrt_inter_cluster_barrier();
-    expected_val += amo_operand * cluster_num;
     if (*atomic_var != expected_val) nerrors++;
     snrt_inter_cluster_barrier();
 
@@ -82,9 +82,9 @@ uint32_t test_atomics(volatile uint32_t* atomic_var) {
      * Test 3: AMOSUB
      ******************************************************/
     amo_operand = 1;
+    expected_val -= amo_operand * cluster_num;
     __atomic_sub_fetch(atomic_var, amo_operand, __ATOMIC_RELAXED);
     snrt_inter_cluster_barrier();
-    expected_val -= amo_operand * cluster_num;
     if (*atomic_var != expected_val) nerrors++;
     snrt_inter_cluster_barrier();
 


### PR DESCRIPTION
This PR will update OBI to the latest revision and change the memory cuts in the L2 memory tile.