### PR TITLE
hw: Remove non-resettable flops in OBI

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -213,7 +213,7 @@ packages:
     - common_cells
     - register_interface
   obi:
-    revision: 95f023208ecaa516860e66a1701a93912ffc62a2
+    revision: 42c635526593cc9353c7adba62275d1919015d87
     version: null
     source:
       Git: https://github.com/pulp-platform/obi.git

--- a/Bender.yml
+++ b/Bender.yml
@@ -14,7 +14,7 @@ dependencies:
   cheshire: { git: "https://github.com/pulp-platform/cheshire.git", rev: "picobello" }
   snitch_cluster:  { git: "https://github.com/pulp-platform/snitch_cluster.git", rev: "develop" }
   floo_noc: { git: "https://github.com/pulp-platform/FlooNoC.git", rev: "fischeti/new-mcast"}
-  obi: { git: "https://github.com/pulp-platform/obi.git", rev: "95f023208ecaa516860e66a1701a93912ffc62a2"}
+  obi: { git: "https://github.com/pulp-platform/obi.git", rev: "42c635526593cc9353c7adba62275d1919015d87"}
   axi_obi: { path: "hw/axi_obi" }
   picobello-pd:  { path: "./pd" }
   fhg_spu_cluster:  { path: "./.deps/fhg_spu_cluster" }


### PR DESCRIPTION
This PR removes non-resettable flops from the OBI atop resolver.