### PR TITLE
sw: Move return code array to the end of L2 memory

### DIFF
--- a/sw/cheshire/tests/simple_offload.c
+++ b/sw/cheshire/tests/simple_offload.c
@@ -8,7 +8,7 @@
 #include "picobello_addrmap.h"
 
 // This needs to be in a region which is not cached
-volatile uint32_t (*return_code_array)[CFG_CLUSTER_NR_CORES] = (uint32_t (*)[CFG_CLUSTER_NR_CORES])0x70008000;
+volatile uint32_t (*return_code_array)[CFG_CLUSTER_NR_CORES] = (uint32_t (*)[CFG_CLUSTER_NR_CORES])0x707FF000;
 
 int main() {
 


### PR DESCRIPTION
This PR changes the return code array address in `simple_offload.c` to (hopefully) not interfere with tests that use large datasets.