### PR TITLE
target/sim: Re-add fast preload in tb and ci and add fast read of L2

### DIFF
--- a/.gitlab/common.yml
+++ b/.gitlab/common.yml
@@ -4,6 +4,7 @@
 
 variables:
   PIP_CACHE_DIR: "$CI_PROJECT_DIR/.cache/pip"
+  PD_COMMIT: "e59863ea5b849814733fbdb262b2e75b9c67369c"
 
 # Sources the environment variables for the IIS environment
 .init-env:

--- a/.gitlab/sw-tests.yml
+++ b/.gitlab/sw-tests.yml
@@ -17,7 +17,7 @@
       - { CHS_BINARY: $CHS_BUILD_DIR/access_l2.spm.elf, PRELMODE: 1}
       - { CHS_BINARY: $CHS_BUILD_DIR/simple_offload.spm.elf, SN_BINARY: $SN_BUILD_DIR/simple.elf, PRELMODE: 0 }
       - { CHS_BINARY: $CHS_BUILD_DIR/simple_offload.spm.elf, SN_BINARY: $SN_BUILD_DIR/simple.elf, PRELMODE: 1 }
-      # - { CHS_BINARY: $CHS_BUILD_DIR/simple_offload.spm.elf, SN_BINARY: $SN_BUILD_DIR/simple.elf, PRELMODE: 3 }
+      - { CHS_BINARY: $CHS_BUILD_DIR/simple_offload.spm.elf, SN_BINARY: $SN_BUILD_DIR/simple.elf, PRELMODE: 3 }
       - { CHS_BINARY: $CHS_BUILD_DIR/simple_offload.spm.elf, SN_BINARY: $SN_BUILD_DIR/non_null_exitcode.elf, NZ_EXIT_CODE: 896 }
       - { CHS_BINARY: $CHS_BUILD_DIR/simple_offload.spm.elf, SN_BINARY: $SN_BUILD_DIR/multicluster_atomics.elf }
       - { CHS_BINARY: $CHS_BUILD_DIR/simple_offload.spm.elf, SN_BINARY: $SN_BUILD_DIR/mcast_barrier.elf }

--- a/Makefile
+++ b/Makefile
@@ -94,10 +94,10 @@ floo-clean:
 ###################
 
 PD_REMOTE ?= git@iis-git.ee.ethz.ch:picobello/picobello-pd.git
-PD_COMMIT ?= f00937b43b8b0e5568adced59c833787e1c99efb
+PD_COMMIT ?= main
 PD_DIR = $(PB_ROOT)/pd
 SPU_REMOTE ?= git@iis-git.ee.ethz.ch:picobello/fhg_spu_cluster.git
-SPU_COMMIT ?= 7c50fc53b895dba4a14575435c49d289963ecfb4
+SPU_COMMIT ?= main
 SPU_DIR = $(PB_ROOT)/.deps/fhg_spu_cluster
 
 .PHONY: init-pd clean-pd

--- a/hw/mem_tile.sv
+++ b/hw/mem_tile.sv
@@ -14,10 +14,6 @@ module mem_tile
   import picobello_pkg::*;
   import obi_pkg::*;
 #(
-  // The maximum data width of the instantiated SRAMs
-  parameter int unsigned SramDataWidth  = 128,   // in bits
-  // The number of words in the instantiated SRAMs
-  parameter int unsigned SramNumWords   = 1024,  // in #words
   parameter bit          AxiUserAtop    = 1'b1,
   parameter int unsigned AxiUserAtopMsb = 3,
   parameter int unsigned AxiUserAtopLsb = 0
@@ -35,25 +31,6 @@ module mem_tile
   output floo_rsp_t  [West:North] floo_rsp_o,
   input  floo_wide_t [West:North] floo_wide_i
 );
-
-  // The number of banks required to store a wide word
-  localparam int unsigned NumBanksPerWord = AxiCfgW.DataWidth / SramDataWidth;
-  // The number of macros required to store the entire memory
-  localparam int unsigned NumBankRows = (MemTileSize / (AxiCfgW.DataWidth / 8)) / SramNumWords;
-
-  // The number of LSBs to address the bytes in an SRAM word
-  localparam int unsigned SramByteOffsetWidth = $clog2(SramDataWidth / 8);
-  // The number of bits required to select the subbank for a wide word
-  localparam int unsigned SramBankSelWidth = $clog2(NumBanksPerWord);
-  // The number of bits for the SRAM address
-  localparam int unsigned SramAddrWidth = $clog2(SramNumWords);
-  // The number of bits to index the SRAM macro
-  localparam int unsigned SramMacroSelWidth = $clog2(NumBankRows);
-
-  // Various offsets for the SRAM address
-  localparam int unsigned SramBankSelOffset = SramByteOffsetWidth;
-  localparam int unsigned SramAddrWidthOffset = SramBankSelOffset + SramBankSelWidth;
-  localparam int unsigned SramMacroSelOffset = SramAddrWidthOffset + SramAddrWidth;
 
   ////////////
   // Router //

--- a/hw/picobello_pkg.sv
+++ b/hw/picobello_pkg.sv
@@ -442,5 +442,28 @@ package picobello_pkg;
 
   // The L2 SPM memory size of every mem tile
   localparam int unsigned MemTileSize = ep_addr_size(L2Spm0SamIdx);
+  // The maximum data width of the instantiated SRAMs
+  localparam int unsigned SramDataWidth  = 128;   // in bits
+  // The number of words in the instantiated SRAMs
+  localparam int unsigned SramNumWords   = 1024;  // in #words
 
+  // The number of banks required to store a wide word
+  localparam int unsigned NumBanksPerWord = AxiCfgW.DataWidth / SramDataWidth;
+  // The number of macros required to store the entire memory
+  localparam int unsigned NumBankRows = (MemTileSize / (AxiCfgW.DataWidth / 8)) / SramNumWords;
+
+  // The number of LSBs to address the bytes in an SRAM word
+  localparam int unsigned SramByteOffsetWidth = $clog2(SramDataWidth / 8);
+  // The number of bits required to select the subbank for a wide word
+  localparam int unsigned SramBankSelWidth = $clog2(NumBanksPerWord);
+  // The number of bits for the SRAM address
+  localparam int unsigned SramAddrWidth = $clog2(SramNumWords);
+  // The number of bits to index the SRAM macro
+  localparam int unsigned SramMacroSelWidth = $clog2(NumBankRows);
+
+  // Various offsets for the SRAM address
+  localparam int unsigned SramBankSelOffset = SramByteOffsetWidth;
+  localparam int unsigned SramAddrWidthOffset = SramBankSelOffset + SramBankSelWidth;
+  localparam int unsigned SramMacroSelOffset = SramAddrWidthOffset + SramAddrWidth;
+  
 endpackage

--- a/hw/picobello_pkg.sv
+++ b/hw/picobello_pkg.sv
@@ -443,9 +443,9 @@ package picobello_pkg;
   // The L2 SPM memory size of every mem tile
   localparam int unsigned MemTileSize = ep_addr_size(L2Spm0SamIdx);
   // The maximum data width of the instantiated SRAMs
-  localparam int unsigned SramDataWidth  = 128;   // in bits
+  localparam int unsigned SramDataWidth = 128;  // in bits
   // The number of words in the instantiated SRAMs
-  localparam int unsigned SramNumWords   = 1024;  // in #words
+  localparam int unsigned SramNumWords = 1024;  // in #words
 
   // The number of banks required to store a wide word
   localparam int unsigned NumBanksPerWord = AxiCfgW.DataWidth / SramDataWidth;
@@ -465,5 +465,5 @@ package picobello_pkg;
   localparam int unsigned SramBankSelOffset = SramByteOffsetWidth;
   localparam int unsigned SramAddrWidthOffset = SramBankSelOffset + SramBankSelWidth;
   localparam int unsigned SramMacroSelOffset = SramAddrWidthOffset + SramAddrWidth;
-  
+
 endpackage

--- a/target/sim/include/tb_picobello_tasks.svh
+++ b/target/sim/include/tb_picobello_tasks.svh
@@ -27,10 +27,10 @@ for(genvar i = 0; i < NumMemTiles; i++) begin : gen_fastmode_class_per_l2_tile
           l2_sram_class_list[i][j][k] = this;
         endfunction
         task write_word(input int sram_addr, input int byte_offset, input logic [31:0] data);
-          fix.dut.gen_memtile[i].i_mem_tile.gen_sram_banks[j].gen_sram_macros[k].i_mem.sram[sram_addr][byte_offset*8 +: 32] = data;
+          `L2_SRAM_PATH[sram_addr][byte_offset*8 +: 32] = data;
         endtask
         task read_word(input int sram_addr, input int byte_offset, output logic [31:0] data);
-          data = fix.dut.gen_memtile[i].i_mem_tile.gen_sram_banks[j].gen_sram_macros[k].i_mem.sram[sram_addr][byte_offset*8 +: 32];
+          data = `L2_SRAM_PATH[sram_addr][byte_offset*8 +: 32];
         endtask
       endclass
       class_fastmode_l2 w = new;

--- a/target/sim/include/tb_picobello_tasks.svh
+++ b/target/sim/include/tb_picobello_tasks.svh
@@ -21,7 +21,7 @@ localparam int AddrWideL2Row       = $clog2(L2NumBankRows); //4
 localparam int AddrStartL2SramAddr = AddrWideL2Col + 4; //6
 localparam int AddrStartL2Row      = AddrStartL2SramAddr + AddrWideL2SramAddr; //16
 
-// FAST_PRELOAD mode trick with virtual class to write directly to L2 sram module inside varius for generate
+// FAST_PRELOAD mode trick with virtual class to write directly to L2 sram module inside various for generate
 virtual class virtual_class_fastmode_write_l2;
   pure virtual task write_word(input int sram_addr, input int byte_offset, input logic [31:0] data);
 endclass

--- a/target/sim/include/tb_picobello_tasks.svh
+++ b/target/sim/include/tb_picobello_tasks.svh
@@ -9,6 +9,8 @@ import "DPI-C" function byte get_entry(output longint entry);
 import "DPI-C" function byte get_section(output longint address, output longint len);
 import "DPI-C" context function byte read_section(input longint address, inout byte buffer[], input longint len);
 
+import picobello_pkg::*;
+
 // FAST_PRELOAD mode trick with virtual class to write directly to L2 sram module inside various for generate
 virtual class virtual_class_fastmode_l2;
   pure virtual task write_word(input int sram_addr, input int byte_offset, input logic [31:0] data);
@@ -75,7 +77,7 @@ task automatic fastmode_read_word(input longint addr, output logic [31:0] data);
 
 endtask
 
-// Read full L@ memory
+// Read full L2 memory
 task automatic fastmode_read();
   import floo_picobello_noc_pkg::*;
   logic [31:0] data;

--- a/target/sim/src/tb_picobello_top.sv
+++ b/target/sim/src/tb_picobello_top.sv
@@ -6,6 +6,8 @@
 
 module tb_picobello_top;
 
+  import picobello_pkg::*;
+
   `include "tb_picobello_tasks.svh"
 
   fixture_picobello_top fix ();

--- a/target/sim/src/tb_picobello_top.sv
+++ b/target/sim/src/tb_picobello_top.sv
@@ -6,7 +6,8 @@
 
 module tb_picobello_top;
 
-  `define L2_SRAM_PATH fix.dut.gen_memtile[i].i_mem_tile.gen_sram_banks[j].gen_sram_macros[k].i_mem.sram
+  `define L2_SRAM_PATH fix.dut.gen_memtile[i].i_mem_tile.\
+                       gen_sram_banks[j].gen_sram_macros[k].i_mem.sram
 
   `include "tb_picobello_tasks.svh"
 

--- a/target/sim/src/tb_picobello_top.sv
+++ b/target/sim/src/tb_picobello_top.sv
@@ -6,8 +6,6 @@
 
 module tb_picobello_top;
 
-  import picobello_pkg::*;
-
   `include "tb_picobello_tasks.svh"
 
   // Instantiate the fixture

--- a/target/sim/src/tb_picobello_top.sv
+++ b/target/sim/src/tb_picobello_top.sv
@@ -6,6 +6,8 @@
 
 module tb_picobello_top;
 
+  `define L2_SRAM_PATH fix.dut.gen_memtile[i].i_mem_tile.gen_sram_banks[j].gen_sram_macros[k].i_mem.sram
+
   `include "tb_picobello_tasks.svh"
 
   // Instantiate the fixture

--- a/target/sim/src/tb_picobello_top.sv
+++ b/target/sim/src/tb_picobello_top.sv
@@ -79,6 +79,7 @@ module tb_picobello_top;
           // TODO(fischeti): Implement fast mode for Cheshire binary
           fix.vip.jtag_elf_run(preload_elf);
           fix.vip.jtag_wait_for_eoc(exit_code);
+          if (snitch_preload) fastmode_read();
         end
         default: begin
           $fatal(1, "Unsupported preload mode %d (reserved)!", boot_mode);

--- a/target/sim/src/tb_picobello_top.sv
+++ b/target/sim/src/tb_picobello_top.sv
@@ -10,6 +10,7 @@ module tb_picobello_top;
 
   `include "tb_picobello_tasks.svh"
 
+  // Instantiate the fixture
   fixture_picobello_top fix ();
 
   string        preload_elf;

--- a/target/sim/src/tb_picobello_top.sv
+++ b/target/sim/src/tb_picobello_top.sv
@@ -8,7 +8,7 @@ module tb_picobello_top;
 
   `include "tb_picobello_tasks.svh"
 
-fixture_picobello_top fix ();
+  fixture_picobello_top fix ();
 
   string        preload_elf;
   string        boot_hex;


### PR DESCRIPTION
This merge:

- reimplements fast preload of L2
- implements sfast read of L2 and dump bin file
- reimplements fast preload simulation in ci
- bumps the commit of PD and SPU repo to main in makefile
- fixes a PD repo commit for ci
- moves some L2 parameters from mem_tile to picobello_pkg