### PR TITLE
tb: Add fast read function for software check

### DIFF
--- a/target/sim/src/tb_picobello_top.sv
+++ b/target/sim/src/tb_picobello_top.sv
@@ -78,6 +78,7 @@ module tb_picobello_top;
           // TODO(fischeti): Implement fast mode for Cheshire binary
           fix.vip.jtag_elf_run(preload_elf);
           fix.vip.jtag_wait_for_eoc(exit_code);
+          if (snitch_preload) fastmode_read();
         end
         default: begin
           $fatal(1, "Unsupported preload mode %d (reserved)!", boot_mode);


### PR DESCRIPTION
# FAST READ 
This PR introdces the possibility of reading the entire L2 memory and dump the content into a file for post simulation checks