### PR TITLE
deps: Clean `common_cells` dependency

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -131,7 +131,7 @@ packages:
     - scm
     - tech_cells_generic
   common_cells:
-    revision: cd88d4d3288d299c819b4d3754269fce080d0b34
+    revision: 265b4cf5fe561cb837899c580f392ea93bf7e147
     version: null
     source:
       Git: https://github.com/pulp-platform/common_cells.git
@@ -168,7 +168,7 @@ packages:
       Path: .deps/fhg_spu_cluster
     dependencies: []
   floo_noc:
-    revision: acee34554708383b7aff1fa1af140aeffb8f3c19
+    revision: ea35a9909d60d552bbdafc7e898590f326b1898a
     version: null
     source:
       Git: https://github.com/pulp-platform/FlooNoC.git

--- a/Bender.lock
+++ b/Bender.lock
@@ -168,7 +168,7 @@ packages:
       Path: .deps/fhg_spu_cluster
     dependencies: []
   floo_noc:
-    revision: c1937c98f3dc92beb43a125e1aab9f5ff7c78dd5
+    revision: acee34554708383b7aff1fa1af140aeffb8f3c19
     version: null
     source:
       Git: https://github.com/pulp-platform/FlooNoC.git

--- a/Bender.yml
+++ b/Bender.yml
@@ -10,7 +10,7 @@ package:
 dependencies:
   register_interface: { git: "https://github.com/pulp-platform/register_interface.git", version: "0.4.5" }
   axi: { git: "https://github.com/pulp-platform/axi.git", version: "0.39.6" }
-  common_cells: { git: "https://github.com/pulp-platform/common_cells.git", rev: "fix/addr-decode-idx" }
+  common_cells: { git: "https://github.com/pulp-platform/common_cells.git", version: "1.37.0" }
   cheshire: { git: "https://github.com/pulp-platform/cheshire.git", rev: "picobello" }
   snitch_cluster:  { git: "https://github.com/pulp-platform/snitch_cluster.git", rev: "develop" }
   floo_noc: { git: "https://github.com/pulp-platform/FlooNoC.git", rev: "fischeti/new-mcast"}

--- a/Bender.yml
+++ b/Bender.yml
@@ -13,7 +13,7 @@ dependencies:
   common_cells: { git: "https://github.com/pulp-platform/common_cells.git", version: "1.37.0" }
   cheshire: { git: "https://github.com/pulp-platform/cheshire.git", rev: "picobello" }
   snitch_cluster:  { git: "https://github.com/pulp-platform/snitch_cluster.git", rev: "develop" }
-  floo_noc: { git: "https://github.com/pulp-platform/FlooNoC.git", rev: "fischeti/new-mcast"}
+  floo_noc: { git: "https://github.com/pulp-platform/FlooNoC.git", rev: "develop"}
   obi: { git: "https://github.com/pulp-platform/obi.git", rev: "42c635526593cc9353c7adba62275d1919015d87"}
   axi_obi: { path: "hw/axi_obi" }
   picobello-pd:  { path: "./pd" }


### PR DESCRIPTION
This PR points to the main branch of `common_cells` and updates FlooNoC commit to fix `addr_decode_dync` syntehsis issue 