### PR TITLE
hw: Support weight dequantization w/ RedMulE

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -321,7 +321,7 @@ packages:
       Path: pd
     dependencies: []
   redmule:
-    revision: d8b6d7c3a5d0464349aa8f2c19be764915662fd4
+    revision: 2e79b95954775f1df21328edcd8816b19620fdc8
     version: null
     source:
       Git: https://github.com/pulp-platform/redmule

--- a/Bender.yml
+++ b/Bender.yml
@@ -46,6 +46,7 @@ sources:
   # Level 1
   - hw/picobello_pkg.sv
   - hw/snitch_hwpe_subsystem.sv
+  - hw/snitch_tcdm_aligner.sv
   # Level 2
   - hw/cluster_tile.sv
   - hw/cheshire_tile.sv

--- a/hw/cluster_tile.sv
+++ b/hw/cluster_tile.sv
@@ -183,7 +183,7 @@ module cluster_tile
     .tcdm_req_aligned_o   (cluster_tcdm_ext_req_aligned),
     .tcdm_rsp_aligned_i   (cluster_tcdm_ext_rsp_aligned),
     .tcdm_rsp_misaligned_o(cluster_tcdm_ext_rsp_misaligned)
-);
+  );
 
   snitch_hwpe_subsystem #(
     .tcdm_req_t   (snitch_cluster_pkg::tcdm_dma_req_t),

--- a/hw/snitch_tcdm_aligner.sv
+++ b/hw/snitch_tcdm_aligner.sv
@@ -44,13 +44,16 @@ module snitch_tcdm_aligner
   assign tcdm_req_aligned_o.q.addr = tcdm_req_misaligned_i.q.addr & AddrMask;
   assign tcdm_req_aligned_o.q.write = tcdm_req_misaligned_i.q.write;
   assign tcdm_req_aligned_o.q.amo = tcdm_req_misaligned_i.q.amo;
-  assign tcdm_req_aligned_o.q.data  = tcdm_req_misaligned_i.q.data << (addr_significant_d * TCDMDataWidth);
-  assign tcdm_req_aligned_o.q.strb  = tcdm_req_misaligned_i.q.strb << (addr_significant_d * TCDMDataWidth/8);
+  assign tcdm_req_aligned_o.q.data  = tcdm_req_misaligned_i.q.data
+                                          << (addr_significant_d * TCDMDataWidth);
+  assign tcdm_req_aligned_o.q.strb  = tcdm_req_misaligned_i.q.strb
+                                          << (addr_significant_d * TCDMDataWidth/8);
   assign tcdm_req_aligned_o.q.user = tcdm_req_misaligned_i.q.user;
   assign tcdm_req_aligned_o.q_valid = tcdm_req_misaligned_i.q_valid;
 
   // Bind tcdm_rsp_misaligned_o signals
-  assign tcdm_rsp_misaligned_o.p.data  = tcdm_rsp_aligned_i.p.data >> (addr_significant_q * TCDMDataWidth);
+  assign tcdm_rsp_misaligned_o.p.data  = tcdm_rsp_aligned_i.p.data
+                                             >> (addr_significant_q * TCDMDataWidth);
   assign tcdm_rsp_misaligned_o.p_valid = tcdm_rsp_aligned_i.p_valid;
   assign tcdm_rsp_misaligned_o.q_ready = tcdm_rsp_aligned_i.q_ready;
 

--- a/hw/snitch_tcdm_aligner.sv
+++ b/hw/snitch_tcdm_aligner.sv
@@ -21,12 +21,16 @@ module snitch_tcdm_aligner
   output tcdm_rsp_t tcdm_rsp_misaligned_o
 );
 
-  localparam logic [AddrWidth-1:0] AddrMask  = ~(DataWidth/8-1);
+  localparam logic [AddrWidth-1:0] AddrMask = ~(DataWidth / 8 - 1);
 
   logic [$clog2(DataWidth/TCDMDataWidth)-1:0] addr_significant_d, addr_significant_q;
 
 
-  assign addr_significant_d = tcdm_req_misaligned_i.q.addr[$clog2(DataWidth/8)-1:$clog2(TCDMDataWidth/8)];
+  assign addr_significant_d = tcdm_req_misaligned_i.q.addr[$clog2(
+      DataWidth/8
+  )-1:$clog2(
+      TCDMDataWidth/8
+  )];
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (~rst_ni) begin
@@ -37,12 +41,12 @@ module snitch_tcdm_aligner
   end
 
   // Bind tcdm_req_aligned_o signals
-  assign tcdm_req_aligned_o.q.addr  = tcdm_req_misaligned_i.q.addr & AddrMask;
+  assign tcdm_req_aligned_o.q.addr = tcdm_req_misaligned_i.q.addr & AddrMask;
   assign tcdm_req_aligned_o.q.write = tcdm_req_misaligned_i.q.write;
-  assign tcdm_req_aligned_o.q.amo   = tcdm_req_misaligned_i.q.amo;
+  assign tcdm_req_aligned_o.q.amo = tcdm_req_misaligned_i.q.amo;
   assign tcdm_req_aligned_o.q.data  = tcdm_req_misaligned_i.q.data << (addr_significant_d * TCDMDataWidth);
   assign tcdm_req_aligned_o.q.strb  = tcdm_req_misaligned_i.q.strb << (addr_significant_d * TCDMDataWidth/8);
-  assign tcdm_req_aligned_o.q.user  = tcdm_req_misaligned_i.q.user;
+  assign tcdm_req_aligned_o.q.user = tcdm_req_misaligned_i.q.user;
   assign tcdm_req_aligned_o.q_valid = tcdm_req_misaligned_i.q_valid;
 
   // Bind tcdm_rsp_misaligned_o signals

--- a/hw/snitch_tcdm_aligner.sv
+++ b/hw/snitch_tcdm_aligner.sv
@@ -1,0 +1,53 @@
+// Copyright 2025 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+`include "hci_helpers.svh"
+
+module snitch_tcdm_aligner
+  import reqrsp_pkg::amo_op_e;
+#(
+  parameter type         tcdm_req_t    = logic,
+  parameter type         tcdm_rsp_t    = logic,
+  parameter int unsigned DataWidth     = 512,
+  parameter int unsigned TCDMDataWidth = 64,
+  parameter int unsigned AddrWidth     = 48
+) (
+  input  logic      clk_i,
+  input  logic      rst_ni,
+  input  tcdm_req_t tcdm_req_misaligned_i,
+  output tcdm_req_t tcdm_req_aligned_o,
+  input  tcdm_rsp_t tcdm_rsp_aligned_i,
+  output tcdm_rsp_t tcdm_rsp_misaligned_o
+);
+
+  localparam logic [AddrWidth-1:0] AddrMask  = ~(DataWidth/8-1);
+
+  logic [$clog2(DataWidth/TCDMDataWidth)-1:0] addr_significant_d, addr_significant_q;
+
+
+  assign addr_significant_d = tcdm_req_misaligned_i.q.addr[$clog2(DataWidth/8)-1:$clog2(TCDMDataWidth/8)];
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (~rst_ni) begin
+      addr_significant_q <= '0;
+    end else if (tcdm_rsp_aligned_i.q_ready) begin
+      addr_significant_q <= addr_significant_d;
+    end
+  end
+
+  // Bind tcdm_req_aligned_o signals
+  assign tcdm_req_aligned_o.q.addr  = tcdm_req_misaligned_i.q.addr & AddrMask;
+  assign tcdm_req_aligned_o.q.write = tcdm_req_misaligned_i.q.write;
+  assign tcdm_req_aligned_o.q.amo   = tcdm_req_misaligned_i.q.amo;
+  assign tcdm_req_aligned_o.q.data  = tcdm_req_misaligned_i.q.data << (addr_significant_d * TCDMDataWidth);
+  assign tcdm_req_aligned_o.q.strb  = tcdm_req_misaligned_i.q.strb << (addr_significant_d * TCDMDataWidth/8);
+  assign tcdm_req_aligned_o.q.user  = tcdm_req_misaligned_i.q.user;
+  assign tcdm_req_aligned_o.q_valid = tcdm_req_misaligned_i.q_valid;
+
+  // Bind tcdm_rsp_misaligned_o signals
+  assign tcdm_rsp_misaligned_o.p.data  = tcdm_rsp_aligned_i.p.data >> (addr_significant_q * TCDMDataWidth);
+  assign tcdm_rsp_misaligned_o.p_valid = tcdm_rsp_aligned_i.p_valid;
+  assign tcdm_rsp_misaligned_o.q_ready = tcdm_rsp_aligned_i.q_ready;
+
+endmodule


### PR DESCRIPTION
This PR bumps the latest RedMulE version with fixes for errors with memory stalls during GEMMs with quantized weights and adds (partial) support for non-512-bit aligned accesses from the accelerators.