### PR TITLE
deps: Bump RedMulE

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -321,7 +321,7 @@ packages:
       Path: pd
     dependencies: []
   redmule:
-    revision: 2e79b95954775f1df21328edcd8816b19620fdc8
+    revision: 8556300b93be5124377113a983907a20dfaa37e6
     version: null
     source:
       Git: https://github.com/pulp-platform/redmule


### PR DESCRIPTION
The current version of RedMulE has a bug that prevents multiple operations from being queued because the internal registers are not correctly reset after an operation finishes. This PR fixes the issue. 