### PR TITLE
fix:  memory tile bandwidth

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -15,15 +15,15 @@ packages:
     - apb
     - common_cells
   apb_uart:
-     revision: 8182a85d234417db46fe833533f8536644d3bee3
-     version: 0.2.3
-     source:
-       Git: https://github.com/pulp-platform/apb_uart.git
-     dependencies:
-     - apb
-     - obi
-     - obi_peripherals
-     - register_interface
+    revision: 8182a85d234417db46fe833533f8536644d3bee3
+    version: 0.2.3
+    source:
+      Git: https://github.com/pulp-platform/apb_uart.git
+    dependencies:
+    - apb
+    - obi
+    - obi_peripherals
+    - register_interface
   axi:
     revision: bec548fa2a9b18cbd7531105bb1fdf481ea8ad49
     version: null
@@ -239,8 +239,11 @@ packages:
       Git: https://github.com/pulp-platform/hci
     dependencies:
     - cluster_interconnect
+    - common_cells
     - hwpe-stream
     - l2_tcdm_hybrid_interco
+    - redundancy_cells
+    - register_interface
   hwpe-ctrl:
     revision: 3690a3c648f120546d8de2bc583d5170c36d2f20
     version: 2.0.0
@@ -290,7 +293,7 @@ packages:
       Git: https://github.com/pulp-platform/L2_tcdm_hybrid_interco.git
     dependencies: []
   obi:
-    revision: 8ceb36dd8b1a2179d56cc7ddb0c31d6b11257a28
+    revision: acfcd0f80c7539aa8da7821a66d9acf2074a5b4e
     version: null
     source:
       Git: https://github.com/pulp-platform/obi.git
@@ -298,13 +301,13 @@ packages:
     - common_cells
     - common_verification
   obi_peripherals:
-     revision: 079894a6cbd4e544c477643d184a4c340bd4e391
-     version: 0.1.1
-     source:
-       Git: https://github.com/pulp-platform/obi_peripherals.git
-     dependencies:
-     - common_cells
-     - obi
+    revision: 079894a6cbd4e544c477643d184a4c340bd4e391
+    version: 0.1.1
+    source:
+      Git: https://github.com/pulp-platform/obi_peripherals.git
+    dependencies:
+    - common_cells
+    - obi
   opentitan_peripherals:
     revision: cd3153de2783abd3d03d0595e6c4b32413c62f14
     version: 0.4.0
@@ -334,6 +337,16 @@ packages:
     - hwpe-ctrl
     - hwpe-stream
     - ibex
+    - tech_cells_generic
+  redundancy_cells:
+    revision: c37bdb47339bf70e8323de8df14ea8bbeafb6583
+    version: null
+    source:
+      Git: https://github.com/pulp-platform/redundancy_cells.git
+    dependencies:
+    - common_cells
+    - common_verification
+    - register_interface
     - tech_cells_generic
   register_interface:
     revision: 5daa85d164cf6b54ad061ea1e4c6f3624556e467
@@ -375,13 +388,13 @@ packages:
     source:
       Git: https://github.com/pulp-platform/snitch_cluster.git
     dependencies:
+    - apb
     - axi
     - axi_riscv_atomics
     - cluster_icache
     - common_cells
     - fpnew
     - idma
-    - register_interface
     - riscv-dbg
     - tech_cells_generic
   tech_cells_generic:

--- a/Bender.yml
+++ b/Bender.yml
@@ -14,7 +14,7 @@ dependencies:
   cheshire:           { git: "https://github.com/pulp-platform/cheshire.git",           rev: "picobello"                                }
   snitch_cluster:     { git: "https://github.com/pulp-platform/snitch_cluster.git",     rev: "d20adf56986cbd7aaaf406602642cd6bdf73701c" }
   floo_noc:           { git: "https://github.com/pulp-platform/FlooNoC.git",            rev: "develop"                                  }
-  obi:                { git: "https://github.com/pulp-platform/obi.git",                rev: "8ceb36dd8b1a2179d56cc7ddb0c31d6b11257a28" }
+  obi:                { git: "https://github.com/pulp-platform/obi.git",                rev: "acfcd0f80c7539aa8da7821a66d9acf2074a5b4e" }
   redmule:            { git: "https://github.com/pulp-platform/redmule.git",            rev: "picobello"                                }
   hci:                { git: "https://github.com/pulp-platform/hci.git",                rev: "06fcba671e060f2e1b03b7ebe2d3e719f1557099" }
   datamover:          { git: "https://github.com/FrancescoConti/datamover.git",         rev: "fb7d09c201ab52de23b11adf12b36d8e75c4c0e6" } # branch: transpose

--- a/hw/axi_obi/Bender.yml
+++ b/hw/axi_obi/Bender.yml
@@ -9,7 +9,7 @@ package:
 
 dependencies:
   axi:          { git: "https://github.com/pulp-platform/axi.git",          version: 0.39.1 }
-  obi:          { git: "https://github.com/pulp-platform/obi.git", rev: "95f023208ecaa516860e66a1701a93912ffc62a2"}
+  obi:          { git: "https://github.com/pulp-platform/obi.git", rev: "acfcd0f80c7539aa8da7821a66d9acf2074a5b4e"}
   common_cells: { git: "https://github.com/pulp-platform/common_cells.git", version: 1.31.1 }
 
 sources:

--- a/hw/axi_obi/src/axi_to_obi.sv
+++ b/hw/axi_obi/src/axi_to_obi.sv
@@ -143,7 +143,7 @@ module axi_to_obi #(
     .UserWidth     (AxiUserWidth),
     .NumBanks      (NumBanks),
     .BufDepth      (MaxTrans),
-    .HideStrb      (1'b1),
+    .HideStrb      (1'b0),
     .OutFifoDepth  (2),
     .PropagateWUser(1'b0),
     .RUserExtra    (IdRuserWidth)
@@ -198,7 +198,7 @@ module axi_to_obi #(
     .UserWidth     (AxiUserWidth),
     .NumBanks      (NumBanks),
     .BufDepth      (MaxTrans),
-    .HideStrb      (1'b1),
+    .HideStrb      (1'b0),
     .OutFifoDepth  (2),
     .PropagateWUser(1'b1),
     .RUserExtra    (IdRuserWidth)

--- a/hw/mem_tile.sv
+++ b/hw/mem_tile.sv
@@ -236,6 +236,9 @@ module mem_tile
                         sbr_obi_r_optional_t)
   `OBI_TYPEDEF_RSP_T(sbr_obi_rsp_t, sbr_obi_r_chan_t)
 
+  // Number of outstanding transactions should be larger than round-trip
+  // latency from converter to SRAM
+  localparam int unsigned ObiLatency = 4;
 
   logic [AxiCfgJoin.OutIdWidth-1:0] axi_in_aw_id, axi_in_ar_id;
   logic [AxiCfgJoin.UserWidth-1:0] axi_in_aw_user, axi_in_ar_user;
@@ -282,7 +285,7 @@ module mem_tile
     .AxiDataWidth(AxiCfgJoin.DataWidth),
     .AxiIdWidth  (AxiCfgJoin.OutIdWidth),
     .AxiUserWidth(AxiCfgJoin.UserWidth),
-    .MaxTrans    (4),
+    .MaxTrans    (ObiLatency),
     .axi_req_t   (axi_nw_join_req_t),
     .axi_rsp_t   (axi_nw_join_rsp_t)
   ) i_axi_to_obi (
@@ -333,6 +336,7 @@ module mem_tile
   logic [ AxiCfgW.DataWidth/8-1:0] mem_be;
   logic [   AxiCfgW.DataWidth-1:0] mem_rdata;
 
+
   obi_atop_resolver #(
     .SbrPortObiCfg            (MgrObiCfg),
     .MgrPortObiCfg            (SbrObiCfg),
@@ -344,7 +348,7 @@ module mem_tile
     .mgr_port_obi_r_optional_t(sbr_obi_r_optional_t),
     .LrScEnable               (1'b1),
     .RiscvWordWidth           (32),
-    .NumTxns (4)
+    .NumTxns                  (ObiLatency)
   ) i_obi_atop_resolver (
     .clk_i         (tile_clk),
     .rst_ni        (tile_rst_n),

--- a/hw/mem_tile.sv
+++ b/hw/mem_tile.sv
@@ -282,7 +282,7 @@ module mem_tile
     .AxiDataWidth(AxiCfgJoin.DataWidth),
     .AxiIdWidth  (AxiCfgJoin.OutIdWidth),
     .AxiUserWidth(AxiCfgJoin.UserWidth),
-    .MaxTrans    (2),
+    .MaxTrans    (4),
     .axi_req_t   (axi_nw_join_req_t),
     .axi_rsp_t   (axi_nw_join_rsp_t)
   ) i_axi_to_obi (
@@ -343,7 +343,8 @@ module mem_tile
     .mgr_port_obi_a_optional_t(sbr_obi_a_optional_t),
     .mgr_port_obi_r_optional_t(sbr_obi_r_optional_t),
     .LrScEnable               (1'b1),
-    .RiscvWordWidth           (32)
+    .RiscvWordWidth           (32),
+    .NumTxns (4)
   ) i_obi_atop_resolver (
     .clk_i         (tile_clk),
     .rst_ni        (tile_rst_n),


### PR DESCRIPTION
# Memory Tile Bandwidth
This PR extends the depths of some buffers in the memory tile to fully utilize the available memeory bandwidth. It's also based on the fixes done in the obi_atop_resolver to support multiple oustanding requests as reported in [atop-outst-txns](https://github.com/pulp-platform/obi/commit/f81aa0c3206454fd52da12d502e82b457e9e4cc6).