### PR TITLE
Fix Redmule Timing When PACE is Enabled

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -324,7 +324,7 @@ packages:
       Path: pd
     dependencies: []
   redmule:
-    revision: c73340288e0dbb3b9cafd99d23304f3c184d3d76
+    revision: eb4a8e8ccd3431ca3b7e6b0d2d060e556eeee0ef
     version: null
     source:
       Git: https://github.com/pulp-platform/redmule

--- a/Bender.lock
+++ b/Bender.lock
@@ -324,7 +324,7 @@ packages:
       Path: pd
     dependencies: []
   redmule:
-    revision: d525ba195d15861672317a757e5150c1a2d6260d
+    revision: c73340288e0dbb3b9cafd99d23304f3c184d3d76
     version: null
     source:
       Git: https://github.com/pulp-platform/redmule

--- a/Bender.lock
+++ b/Bender.lock
@@ -324,7 +324,7 @@ packages:
       Path: pd
     dependencies: []
   redmule:
-    revision: b2b12f7e5eb7374ee868f0a5e1a2c09ddd527536
+    revision: d525ba195d15861672317a757e5150c1a2d6260d
     version: null
     source:
       Git: https://github.com/pulp-platform/redmule


### PR DESCRIPTION
The old Redmule commit had a very long critical path between the last and first CE of each row when PACE was enabled. This PR fixes the issue.