### PR TITLE
[deps] point to Redmule version used in tapeout

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -324,7 +324,7 @@ packages:
       Path: pd
     dependencies: []
   redmule:
-    revision: b2b12f7e5eb7374ee868f0a5e1a2c09ddd527536
+    revision: 6fb7c175a784e1161a6762ab91d9b296697a66f1
     version: null
     source:
       Git: https://github.com/pulp-platform/redmule


### PR DESCRIPTION
This PR updates the Bender.lock file to point to the Redmule version used in the tapeout. This Redmule version features 128 CEs and disables the noncomp modules.