### PR TITLE
target/sim: Fix JTAG preloading of Snitch binary

### DIFF
--- a/target/sim/src/tb_picobello_top.sv
+++ b/target/sim/src/tb_picobello_top.sv
@@ -25,6 +25,33 @@ module tb_picobello_top;
   int           snitch_fn;
   int           chs_fn;
 
+  // Load Snitch binary
+  task automatic jtag_32b_elf_preload(input string binary, output bit [63:0] entry);
+    longint sec_addr, sec_len;
+    dm::sbcs_t sbcs = dm::sbcs_t'{
+      sbautoincrement: 1'b1, sbreadondata: 1'b1, sbaccess: 2, default: '0};
+    $display("[JTAG] Preloading ELF binary: %s", binary);
+    if (fix.vip.read_elf(binary))
+      $fatal(1, "[JTAG] Failed to load ELF!");
+    while (fix.vip.get_section(sec_addr, sec_len)) begin
+      byte bf[] = new [sec_len];
+      $display("[JTAG] Preloading section at 0x%h (%0d bytes)", sec_addr, sec_len);
+      if (fix.vip.read_section(sec_addr, bf, sec_len)) $fatal(1, "[JTAG] Failed to read ELF section!");
+      fix.vip.jtag_write(dm::SBCS, sbcs, 1, 1);
+      // Write address as 64-bit double
+      fix.vip.jtag_write(dm::SBAddress1, sec_addr[63:32]);
+      fix.vip.jtag_write(dm::SBAddress0, sec_addr[31:0]);
+      for (longint i = 0; i <= sec_len ; i += 4) begin
+        bit checkpoint = (i != 0 && i % 512 == 0);
+        if (checkpoint)
+          $display("[JTAG] - %0d/%0d bytes (%0d%%)", i, sec_len, i*100/(sec_len>1 ? sec_len-1 : 1));
+        fix.vip.jtag_write(dm::SBData0, {bf[i+3], bf[i+2], bf[i+1], bf[i]}, checkpoint, checkpoint);
+      end
+    end
+    void'(get_entry(entry));
+    $display("[JTAG] Preload complete");
+  endtask
+
   initial begin
     // Fetch plusargs or use safe (fail-fast) defaults
     if (!$value$plusargs("BOOTMODE=%d", boot_mode)) boot_mode = 0;
@@ -60,7 +87,7 @@ module tb_picobello_top;
       case (preload_mode)
         0: begin  // JTAG
           jtag_enable_tiles();  // Write control registers
-          if (snitch_preload) fix.vip.jtag_elf_preload(snitch_elf, snitch_entry);
+          if (snitch_preload) jtag_32b_elf_preload(snitch_elf, snitch_entry);
           fix.vip.jtag_elf_run(preload_elf);
           fix.vip.jtag_wait_for_eoc(exit_code);
         end


### PR DESCRIPTION
Cheshire's `jtag_elf_preload` function requires all ELF sections to be 64b-aligned, which is not the case for Snitch binaries.

See also https://github.com/pulp-platform/cheshire/pull/244.