### PR TITLE
[TB] Fix slink preload when sections are not 64-bit aligned

### DIFF
--- a/target/sim/src/tb_picobello_top.sv
+++ b/target/sim/src/tb_picobello_top.sv
@@ -59,6 +59,55 @@ module tb_picobello_top;
     $display("[JTAG] Preload complete");
   endtask
 
+  task automatic slink_32b_elf_preload(input string binary, output doub_bt entry);
+    longint sec_addr, sec_len;
+    $display("[SLINK] Preloading ELF binary: %s", binary);
+    if (fix.vip.read_elf(binary))
+      $fatal(1, "[SLINK] Failed to load ELF!");
+    while (fix.vip.get_section(sec_addr, sec_len)) begin
+      byte bf[] = new [sec_len];
+      int burst_len;
+      $display("[SLINK] Preloading section at 0x%h (%0d bytes)", sec_addr, sec_len);
+      if (fix.vip.read_section(sec_addr, bf, sec_len)) $fatal(1, "[SLINK] Failed to read ELF section!");
+      // Write section in bursts <= SlinkBurstBytes that never cross a 4 KiB page
+      for (longint sec_offs = 0; sec_offs < sec_len; sec_offs += burst_len) begin
+        longint sec_left, page_left;
+        axi_data_t beats[$];
+        int bus_offs;
+        addr_t addr_cur = sec_addr + sec_offs;
+        if (sec_offs != 0) begin
+          $display("[SLINK] - %0d/%0d bytes (%0d%%)", sec_offs, sec_len,
+                   sec_offs*100/(sec_len > 1 ? sec_len - 1 : 1));
+        end
+        // By default the burst length is SlinkBurstBytes
+        burst_len = SlinkBurstBytes;
+        // Cut the burst length if it exceeds the remaining section length
+        // or it crosses a 4 KiB page boundary
+        sec_left  = sec_len - sec_offs;
+        page_left = 4096 - (addr_cur & 12'hFFF);
+        if (burst_len > sec_left)  burst_len = int'(sec_left);
+        if (burst_len > page_left) burst_len = int'(page_left);
+        bus_offs = addr_cur[AxiStrbBits-1:0];
+
+        // If the address is not aligned subtract the offset from the burst length to avoid an additional write
+        burst_len = burst_len - bus_offs;
+        // Assemble beats, handling unaligned start in the first beat
+        for (int b = -bus_offs; b < burst_len; b += AxiStrbWidth) begin
+          axi_data_t beat = '0;
+          for (int e = 0; e < AxiStrbWidth; ++e)
+            if (b + e >= 0 && b + e < burst_len)
+              beat[8*e +: 8] = bf[sec_offs + b + e];
+          beats.push_back(beat);
+        end
+        // Address must be beat‑aligned for slink_write_beats
+          fix.vip.slink_write_beats(addr_cur - bus_offs, AxiStrbBits, beats);
+      end
+    end
+    void'(fix.vip.get_entry(entry));
+    $display("[SLINK] Preload complete");
+  endtask
+
+
   initial begin
     // Fetch plusargs or use safe (fail-fast) defaults
     if (!$value$plusargs("BOOTMODE=%d", boot_mode)) boot_mode = 0;
@@ -100,7 +149,7 @@ module tb_picobello_top;
         end
         1: begin  // Serial Link
           slink_enable_tiles();  // Write control registers
-          if (snitch_preload) fix.vip.slink_elf_preload(snitch_elf, snitch_entry);
+          if (snitch_preload) slink_32b_elf_preload(snitch_elf, snitch_entry);
           fix.vip.slink_elf_run(preload_elf);
           fix.vip.slink_wait_for_eoc(exit_code);
         end


### PR DESCRIPTION
This PR fixes a bug that caused elf files with non-64-bit aligned sections to load incorrectly.