### PR TITLE
deps: Bump cheshire

### DIFF
--- a/.github/workflows/gitlab-ci.yml
+++ b/.github/workflows/gitlab-ci.yml
@@ -17,7 +17,7 @@ jobs:
       name: Mirror and check
       runs-on: ubuntu-latest
       steps:
-        - uses: pulp-platform/pulp-actions/gitlab-ci@v2.4.1
+        - uses: pulp-platform/pulp-actions/gitlab-ci@v2.4.5
           # Skip on forks or pull requests from forks due to missing secrets.
           if: >
             github.repository == 'pulp-platform/picobello' &&

--- a/Bender.lock
+++ b/Bender.lock
@@ -88,7 +88,7 @@ packages:
     - common_cells
     - register_interface
   cheshire:
-    revision: 0bebd9a2d6edb4665b00d2db9442c059692c0664
+    revision: 4a3932e1bfb8ab72b2d934d65667caefbe2884fc
     version: null
     source:
       Git: https://github.com/pulp-platform/cheshire.git
@@ -175,7 +175,7 @@ packages:
       Git: https://github.com/pulp-platform/cv32e40x.git
     dependencies: []
   cva6:
-    revision: 9338c2ca7cf1a47aef54322f89ce867825c3c8d5
+    revision: 4c02b24fe7c04690f626776a92274da24f80d1da
     version: null
     source:
       Git: https://github.com/pulp-platform/cva6.git
@@ -225,7 +225,7 @@ packages:
       Path: .bender/git/checkouts/floo_noc-051cdbf4a4876727/./pd
     dependencies: []
   fpnew:
-    revision: a8e0cba6dd50f357ece73c2c955d96efc3c6c315
+    revision: e5aa6a01b5bbe1675c3aa8872e1203413ded83d1
     version: null
     source:
       Git: https://github.com/pulp-platform/cvfpu.git

--- a/Bender.yml
+++ b/Bender.yml
@@ -11,7 +11,7 @@ dependencies:
   register_interface: { git: "https://github.com/pulp-platform/register_interface.git", version: "0.4.5"                                }
   axi:                { git: "https://github.com/pulp-platform/axi.git",                version: "0.39.6"                               }
   common_cells:       { git: "https://github.com/pulp-platform/common_cells.git",       rev: "snitch"                                   }
-  cheshire:           { git: "https://github.com/pulp-platform/cheshire.git",           rev: "picobello"                                }
+  cheshire:           { git: "https://github.com/pulp-platform/cheshire.git",           rev: "main"                                     }
   snitch_cluster:     { git: "https://github.com/pulp-platform/snitch_cluster.git",     rev: "5d6c957c70e3824e2330d8308eb904724cd41cbe" }
   floo_noc:           { git: "https://github.com/pulp-platform/FlooNoC.git",            version: "0.7.0"                                }
   obi:                { git: "https://github.com/pulp-platform/obi.git",                rev: "acfcd0f80c7539aa8da7821a66d9acf2074a5b4e" }

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ BENDER_LOCK = $(PB_ROOT)/Bender.lock
 # Bender flags #
 ################
 
-COMMON_TARGS += -t rtl -t cva6 -t cv64a6_imafdcsclic_sv39 -t snitch_cluster -t pb_gen_rtl
+COMMON_TARGS += -t rtl -t cva6 -t cv64a6_imafdchsclic_sv39_wb -t snitch_cluster -t pb_gen_rtl
 SIM_TARGS += -t simulation -t test -t idma_test
 
 #############


### PR DESCRIPTION
the previous `picobello` branch was merged and deleted, so bender complains now. This PR points it to the merged commit upstream again.